### PR TITLE
兼容linux系统的git已是最新提示

### DIFF
--- a/apps/admin.js
+++ b/apps/admin.js
@@ -121,7 +121,7 @@ export async function updateRes(e) {
     e.reply("开始尝试更新，请耐心等待~");
     command = `git pull`;
     exec(command, { cwd: `${resPath}/miao-res-plus/` }, function (error, stdout, stderr) {
-      if (/Already up to date/.test(stdout)) {
+      if (/Already up[ -]to[ -]date/.test(stdout)) {
         e.reply("目前所有图片都已经是最新了~");
         return true;
       }
@@ -165,7 +165,7 @@ export async function updateMiaoPlugin(e) {
     e.reply("正在执行更新操作，请稍等");
   }
   exec(command, { cwd: `${_path}/plugins/miao-plugin/` }, function (error, stdout, stderr) {
-    if (/Already up to date/.test(stdout)) {
+    if (/Already up[ -]to[ -]date/.test(stdout)) {
       e.reply("目前已经是最新版喵喵了~");
       return true;
     }


### PR DESCRIPTION

Windows上是`Already up to date.`

![image](https://user-images.githubusercontent.com/34293221/172117926-0222d066-bbdc-484d-bf84-163a240719be.png)

但是跑到Linux上居然变成了`Already up-to-date.`

![image](https://user-images.githubusercontent.com/34293221/172117824-539a0a16-22da-4197-8a81-ea35faad5c5c.png)

导致无法判断是否是最新版了，这里兼容一下。