### PR TITLE
新增`#获取原图`指令，用于获取角色卡片的原图

### DIFF
--- a/apps/character.js
+++ b/apps/character.js
@@ -390,7 +390,7 @@ async function renderCard(e, avatar, render, renderType = "card") {
     e.reply(segment.image(process.cwd() + "/plugins/miao-plugin/resources/" + bg.img));
   } else {
     //渲染图像
-    return await Common.render("character/card", {
+    let msgRes = await Common.render("character/card", {
       save_id: uid,
       uid,
       talent,
@@ -400,6 +400,11 @@ async function renderCard(e, avatar, render, renderType = "card") {
       ...getCharacterData(avatar),
       ds: char.getData("name,id,title,desc"),
     }, { e, render, scale: 1.6 });
+    if (msgRes && msgRes.message_id) {
+      // 如果消息发送成功，就将message_id和图片路径存起来，1小时过期
+      await redis.set(`miao:original-picture:${msgRes.message_id}`, bg.img, {EX: 3600});
+    }
+    return msgRes;
   }
 
 
@@ -963,5 +968,36 @@ export async function getProfileAll(e) {
 
 export async function profileHelp(e) {
   e.reply(segment.image(`file://${process.cwd()}/plugins/miao-plugin/resources/character/imgs/help.jpg`))
+  return true;
+}
+
+/** 获取角色卡片的原图 */
+export async function getOriginalPicture(e) {
+  if (!e.hasReply) {
+    return;
+  }
+  // 引用的消息不是自己的消息
+  if (e.source.user_id !== e.self_id) {
+    return;
+  }
+  // 引用的消息不是纯图片
+  if (!/^\[图片]$/.test(e.source.message)) {
+    return;
+  }
+  // 获取原消息
+  let source;
+  if (e.isGroup) {
+    source = (await e.group.getChatHistory(e.source.seq, 1)).pop();
+  } else {
+    source = (await e.friend.getChatHistory(e.source.time, 1)).pop();
+  }
+  if (source) {
+    let imgPath = await redis.get(`miao:original-picture:${source.message_id}`);
+    if (imgPath) {
+      e.reply([segment.image(process.cwd() + "/plugins/miao-plugin/resources/" + imgPath)]);
+      return true;
+    }
+  }
+  e.reply("消息太过久远了，俺也忘了原图是啥了，下次早点来吧~");
   return true;
 }

--- a/components/Common.js
+++ b/components/Common.js
@@ -18,7 +18,7 @@ export const render = async function (path, params, cfg) {
   });
 
   if (base64) {
-    e.reply(segment.image(`base64://${base64}`));
+    return await e.reply(segment.image(`base64://${base64}`));
   }
 
   return true;

--- a/index.js
+++ b/index.js
@@ -6,7 +6,8 @@ import {
   enemyLv,
   getArtis,
   getProfileAll,
-  profileHelp
+  profileHelp,
+  getOriginalPicture
 } from "./apps/character.js";
 import { consStat, abyssPct, abyssTeam } from "./apps/stat.js";
 import { wiki, calendar } from "./apps/wiki.js";
@@ -34,7 +35,8 @@ export {
   getProfileAll,
   profileHelp,
   calendar,
-  profileCfg
+  profileCfg,
+  getOriginalPicture
 };
 
 
@@ -59,6 +61,10 @@ let rule = {
   wife: {
     reg: wifeReg,
     describe: "【#角色】#老公 #老婆 查询",
+  },
+  getOriginalPicture: {
+    reg: "^#(获取|给我|我要|求|发|发下|发个|发一下)?原图(吧|呗)?$",
+    describe: "【#原图】 回复角色卡片，可获取原图",
   },
   consStat: {
     reg: "^#(喵喵)?角色(持有|持有率|命座|命之座|.命)(分布|统计|持有|持有率)?$",


### PR DESCRIPTION
为了防止redis缓存无限增长，设置了1个小时的过期时间，这个时间如果感觉不合理可以改一下。

----

关于`miao-plugin/components/Common.js` 第21行的修改，
![image](https://user-images.githubusercontent.com/34293221/173180305-f894f982-03ad-4d9d-bf29-e7cb046270d2.png)

目的是为了获取消息发送后的返回值，但是因为改了公共方法，所以可能会对别的功能造成隐患…… 我在提交之前也都测试过了，目前没有发现别的问题。

云崽这边因为是判断只要返回有值就进入break，所以也能正常进入 break（除非e.reply会返回null……应该不会吧）。
![image](https://user-images.githubusercontent.com/34293221/173180226-a568cc3d-660a-4f6c-b15f-a6a3bd09a84b.png)

所以这么修改应该是没有太大的问题了，如果喵佬觉得不可以这么改那我就可以改成callback的方式

------

操作示例如下：
![IMG_20220611_162644](https://user-images.githubusercontent.com/34293221/173180047-2e649c3e-d772-4279-8df9-a733a32a6167.jpg)
