### PR TITLE
移除 Enka 数据雷神被动加成 fix

### DIFF
--- a/components/profile-data/enka-data.js
+++ b/components/profile-data/enka-data.js
@@ -232,21 +232,22 @@ let Data = {
     let { attr, id } = ret;
     id = id * 1;
     switch (id) {
-      case 10000052:
-        // 雷神被动加成fix
-        attr.dmgBonus = Math.max(0, attr.dmgBonus - (attr.recharge - 100) * 0.4)
-        break;
+      /*
+        case 10000052:
+          // 雷神被动加成fix
+          attr.dmgBonus = Math.max(0, attr.dmgBonus - (attr.recharge - 100) * 0.4)
+          break;
+      */
       case 10000041:
         // 莫娜被动fix
         attr.dmgBonus = Math.max(0, attr.dmgBonus - attr.recharge * 0.2)
         break;
       /*
-            case 10000060:
-              // 夜兰被动fix
-              attr.hp = attr.hp - attr.hpBase * 0.3
-              break;
+        case 10000060:
+          // 夜兰被动fix
+          attr.hp = attr.hp - attr.hpBase * 0.3
+          break;
       */
-
     }
     ret._fix = true;
     return ret;


### PR DESCRIPTION
Fix 之后反而会导致元素加伤为 0，Enka 似乎已经修改了 `__data.json` 中雷电将军的 `fightPropMap.41`

```
{
  // ...
  "avatarInfoList": [
    // ...
    {
      "avatarId": 10000052,
      // ...
      "fightPropMap": {
        "1": 12907.1904296875,
        "2": 4780,
        "3": 0.05829999968409538,
        "4": 846.8474731445312,
        "5": 410.2099914550781,
        "6": 0.6116999983787537,
        "7": 789.305419921875,
        "8": 111.11000061035156,
        "9": 0.2551000118255615,
        "20": 0.5360000133514404,
        "21": 0,
        "22": 0.9273999929428101,
        "23": 2.9960999488830566,
        "26": 0,
        "27": 0,
        "28": 23.309999465942383,
        "29": 0,
        "30": 0,
        "40": 0,
        "41": 0.7984399795532227,
        "42": 0,
        "43": 0,
        "44": 0,
        "45": 0,
        "46": 0,
        "50": 0,
        "51": 0,
        "52": 0,
        "53": 0,
        "54": 0,
        "55": 0,
        "56": 0,
        "71": 90,
        "1001": 90,
        "1010": 18439.6796875,
        "2000": 18439.6796875,
        "2001": 1775.0740966796875,
        "2002": 1101.7672119140625,
        "2003": 0
      },
      // ...
    ]
  },
}
```