### PR TITLE
修正攻击词条评分中的类型错误

### DIFF
--- a/components/models/Reliquaries2.js
+++ b/components/models/Reliquaries2.js
@@ -23,7 +23,7 @@ let Reliquaries = {
       attrMark.hpPlus = attrMark.hp / baseAttr[0] * 100;
     }
     if (attrMark.atk) {
-      attrMark.atkPlus = attrMark.atk / (baseAttr[1] + 400) * 100;
+      attrMark.atkPlus = attrMark.atk / (parseInt(baseAttr[1]) + 400) * 100;
     }
     if (attrMark.def) {
       attrMark.defPlus = attrMark.def / baseAttr[2] * 100;


### PR DESCRIPTION
`char.lvStat.detail['90']` 中数据均为 `String` 类型

![image](https://user-images.githubusercontent.com/22407052/175465616-39959aa7-7c0d-4a5e-a4d5-91bb54f79f10.png)
