### PR TITLE
fix: non-owners cannot upload img

### DIFF
--- a/apps/character/ImgUpload.js
+++ b/apps/character/ImgUpload.js
@@ -117,9 +117,6 @@ async function isAllowedToUploadCharacterImage (e) {
   if (!e.msg) {
     return false
   }
-  if (!e.isMaster) {
-    return false
-  }
 
   // 由于添加角色图是全局，暂时屏蔽非管理员的添加
   if (e.isPrivate) {


### PR DESCRIPTION
groupConfig中支持可配置除主人以外的角色上传图片，但在判定权限时先判断是否为主人，导致即使配置中可由主人以外的人添加图片，但是会在这一步return false