### PR TITLE
圣遗物评分排序应该用数字类型 _mark 而不是字符类型的 mark

### DIFF
--- a/apps/character/ProfileRank.js
+++ b/apps/character/ProfileRank.js
@@ -165,7 +165,7 @@ async function renderCharRankList ({ e, uids, char, mode, groupId }) {
           }
         }
       }
-      tmp._mark = mark?.mark || 0
+      tmp._mark = mark?._mark || 0
       tmp._dmg = dmg?.avg || 0
       tmp._star = 5 - tmp.star
       list.push(tmp)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/11647906/202719341-adc9146f-9c05-485f-a0c1-6b902ee82dd7.png)
使用 mark 字段进行排序会导致 67 分排在 200 分前面