### PR TITLE
add team dmg

### DIFF
--- a/resources/meta/character/八重神子/calc_teamC0R1.js
+++ b/resources/meta/character/八重神子/calc_teamC0R1.js
@@ -1,0 +1,58 @@
+export const details = [{
+  check: ({ cons }) => cons < 2,
+  dmgKey: 'e',
+  title: '温三雷叄阶杀生樱伤害',
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·叁阶'], 'e')
+}, {
+  check: ({ cons }) => cons >= 2,
+  dmgKey: 'e',
+  title: '温三雷肆阶杀生樱伤害',
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'], 'e')
+}, {
+  title: '温三雷Q天狐霆雷伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['天狐霆雷伤害'], 'q')
+}, {
+  title: '温三雷四段Q总伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'] + talent.q['天狐霆雷伤害'] * 3, 'q')
+}]
+
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+export const defDmgKey = 'e'
+
+export const buffs = [{
+  title: '被动天赋：基于元素精通提高杀生樱伤害[eDmg]%',
+  data: {
+    eDmg: ({ attr, calc }) => calc(attr.mastery) * 0.15
+  }
+}, {
+  check: ({ cons }) => cons >= 4,
+  title: '4命效果：杀生樱命中敌人后提高雷伤[dmg]%',
+  data: {
+    dmg: 20
+  }
+}, {
+  cons: 6,
+  title: '6命效果：杀生樱无视敌人[eDef]%防御',
+  data: {
+    eDef: 60
+  }
+}, {
+    title: '精1终末0命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      atkPct:20,
+      kx:40,
+      mastery:100
+   }
+  }, {
+    title: '天空宗室九条：增加[atkPlus]点攻击力,[atkPct]%攻击与[cdmg]%爆伤',
+    data: {
+      atkPlus: 794.2,
+      atkPct:20,
+      cdmg:60
+   }
+  },{
+    title: '恶曜开眼：开E元素爆发伤害提升[qDmg]%',
+    data: {
+      qDmg: 27
+    }
+  }]

--- a/resources/meta/character/八重神子/calc_teamC6R5.js
+++ b/resources/meta/character/八重神子/calc_teamC6R5.js
@@ -1,0 +1,58 @@
+export const details = [{
+  check: ({ cons }) => cons < 2,
+  dmgKey: 'e',
+  title: '温三雷叄阶杀生樱伤害',
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·叁阶'], 'e')
+}, {
+  check: ({ cons }) => cons >= 2,
+  dmgKey: 'e',
+  title: '温三雷肆阶杀生樱伤害',
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'], 'e')
+}, {
+  title: '温三雷Q天狐霆雷伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['天狐霆雷伤害'], 'q')
+}, {
+  title: '温三雷四段Q总伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'] + talent.q['天狐霆雷伤害'] * 3, 'q')
+}]
+
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+export const defDmgKey = 'e'
+
+export const buffs = [{
+  title: '被动天赋：基于元素精通提高杀生樱伤害[eDmg]%',
+  data: {
+    eDmg: ({ attr, calc }) => calc(attr.mastery) * 0.15
+  }
+}, {
+  check: ({ cons }) => cons >= 4,
+  title: '4命效果：杀生樱命中敌人后提高雷伤[dmg]%',
+  data: {
+    dmg: 20
+  }
+}, {
+  cons: 6,
+  title: '6命效果：杀生樱无视敌人[eDef]%防御',
+  data: {
+    eDef: 60
+  }
+}, {
+    title: '精5终末6命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      atkPct:40,
+      kx:60,
+      mastery:200
+   }
+  }, {
+    title: '天空宗室九条：增加[atkPlus]点攻击力,[atkPct]%攻击与[cdmg]%爆伤',
+    data: {
+      atkPlus: 794.2,
+      atkPct:20,
+      cdmg:60
+   }
+  },{
+    title: '恶曜开眼：开E元素爆发伤害提升[qDmg]%',
+    data: {
+      qDmg: 27
+    }
+  }]

--- a/resources/meta/character/刻晴/calc_teamC0R1.js
+++ b/resources/meta/character/刻晴/calc_teamC0R1.js
@@ -1,0 +1,68 @@
+export const details = [{
+  title: '刻九万妲E后重击伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+}, {
+  title: '刻九万妲Q单段伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['连斩伤害2'][0], 'q')
+}, {
+  title: '刻九万妲Q总伤害',
+  params: { q: 1 },
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'] + talent.q['连斩伤害'] + talent.q['最后一击伤害'], 'q')
+}, {
+  title: '刻九万妲Q激化总伤',
+  params: { q: 1 },
+  dmg: ({ talent }, dmg) => {
+    let t1j = dmg(talent.q['技能伤害'], 'q', '超激化')
+    let t2j = dmg(talent.q['连斩伤害'] / 8, 'q', '超激化')
+    let t2 = dmg(talent.q['连斩伤害'] / 8, 'q')
+    let t3j = dmg(talent.q['最后一击伤害'], 'q', '超激化')
+    return {
+      dmg: t1j.dmg + t2j.dmg * 2 + t2.dmg * 6 + t3j.dmg,
+      avg: t1j.avg + t2j.avg * 2 + t2.avg * 6 + t3j.avg
+    }
+  }
+}]
+
+export const defDmgIdx = 3
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const buffs = [{
+  title: '刻晴被动：释放Q获得15%暴击率',
+  data: {
+    qCpct: 15
+  }
+}, {
+  title: '刻晴4命：触发雷元素相关反应提升攻击力25%',
+  cons: 4,
+  data: {
+    atkPct: 25
+  }
+}, {
+  title: '刻晴6命：4层获得24%雷伤加成',
+  cons: 6,
+  data: {
+    dmg: 24
+  }
+},{
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, {
+    title: '宗室天空九条：增加[atkPlus]点攻击力与[cdmg]%爆伤,攻击[atkPct]%',
+    data: {
+      atkPlus: 794.2,
+      cdmg:60,
+      atkPct:20
+   }
+  }, {
+    title: '精1千夜纳西妲：增加精通[mastery]',
+    data: {
+      mastery: 290
+   }
+  }]

--- a/resources/meta/character/刻晴/calc_teamC6R5.js
+++ b/resources/meta/character/刻晴/calc_teamC6R5.js
@@ -1,0 +1,70 @@
+export const details = [{
+  title: '刻九万妲E后重击伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+}, {
+  title: '刻九万妲Q单段伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['连斩伤害2'][0], 'q')
+}, {
+  title: '刻九万妲Q总伤害',
+  params: { q: 1 },
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'] + talent.q['连斩伤害'] + talent.q['最后一击伤害'], 'q')
+}, {
+  title: '刻九万妲Q激化总伤',
+  params: { q: 1 },
+  dmg: ({ talent }, dmg) => {
+    let t1j = dmg(talent.q['技能伤害'], 'q', '超激化')
+    let t2j = dmg(talent.q['连斩伤害'] / 8, 'q', '超激化')
+    let t2 = dmg(talent.q['连斩伤害'] / 8, 'q')
+    let t3j = dmg(talent.q['最后一击伤害'], 'q', '超激化')
+    return {
+      dmg: t1j.dmg + t2j.dmg * 2 + t2.dmg * 6 + t3j.dmg,
+      avg: t1j.avg + t2j.avg * 2 + t2.avg * 6 + t3j.avg
+    }
+  }
+}]
+
+export const defDmgIdx = 3
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const buffs = [{
+  title: '刻晴被动：释放Q获得15%暴击率',
+  data: {
+    qCpct: 15
+  }
+}, {
+  title: '刻晴4命：触发雷元素相关反应提升攻击力25%',
+  cons: 4,
+  data: {
+    atkPct: 25
+  }
+}, {
+  title: '刻晴6命：4层获得24%雷伤加成',
+  cons: 6,
+  data: {
+    dmg: 24
+  }
+},{
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, {
+    title: '宗室天空九条：增加[atkPlus]点攻击力与[cdmg]%爆伤,攻击[atkPct]%',
+    data: {
+      atkPlus: 794.2,
+      cdmg:60,
+      atkPct:20
+   }
+  }, {
+    title: '精5千夜纳西妲：增加精通[mastery],减防[enemyDef]%',
+    data: {
+      mastery: 298,
+      enemyDef: 30
+   }
+  }]

--- a/resources/meta/character/夜兰/calc_teamC0R1.js
+++ b/resources/meta/character/夜兰/calc_teamC0R1.js
@@ -1,0 +1,77 @@
+export const details = [ {
+  title: '夜万香E络命丝伤害',
+  dmg: ({ talent, attr, calc }, { basic }) => basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e')
+
+}, {
+  title: '夜万香E络命丝蒸发',
+  dmg: ({ talent, attr, calc }, { basic }) => basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e', '蒸发')
+
+}, {
+  
+  title: '夜万香Q协同单段伤害',
+  params: { q: true },
+  dmg: ({ talent, attr, calc, cons }, { basic }) => {
+    return basic(calc(attr.hp) * (talent.q['玄掷玲珑伤害'] / 3 / 100), 'q')
+  }
+}, {
+  check: ({ cons }) => cons < 6,
+  dmgKey: 'q',
+  title: 'EE双蒸后台8次连携',
+  params: { q: true },
+  dmg: ({ talent, attr, calc, cons }, { basic }) => {
+    let e_v = basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e', '蒸发')
+    let erming = basic(calc(attr.hp) * (14 / 100), 'q')
+    let count = cons * 1 >= 2 ? 1 : 0
+    let q = basic(calc(attr.hp) * (talent.q['玄掷玲珑伤害'] / 3 / 100), 'q',)
+    return {
+        dmg: 2 * e_v.dmg + 4 * erming.dmg * count+ 24 * q.dmg,
+        avg: 2 * e_v.avg + 4 * erming.avg * count+ 24 * q.avg
+    }
+  }
+}, {
+  check: ({ cons }) => cons >= 6,
+  dmgKey: 'q',
+  title: '6命EaEaaaa双蒸',
+  params: { q: true },
+  dmg: ({ talent, attr, calc, cons }, { basic }) => {
+    let e_v = basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e', '蒸发')
+    let erming = basic(calc(attr.hp) * (14 / 100), 'q')
+    let q = basic(calc(attr.hp) * (talent.q['玄掷玲珑伤害'] / 3 / 100), 'q',)
+    let a = basic(calc(attr.hp) * talent.a['破局矢伤害']*1.56 / 100, 'a2')
+    return {
+        dmg: 2*e_v.dmg + 2*erming.dmg+ 15*q.dmg+ 5*a.dmg,
+        avg: 2*e_v.avg + 2*erming.avg+ 15*q.avg+ 5*a.avg
+    }
+  }
+}]
+
+export const defDmgKey = 'q'
+export const mainAttr = 'hp,cpct,cdmg'
+
+export const buffs = [{
+  title: '夜兰被动：有4个不同元素类型角色时，夜兰生命值上限提高30%',
+  data: {
+    hpPct: 30
+  }
+}, {
+  title: '夜兰4命：E络命丝爆发提高生命值，满Buff下提高40%',
+  cons: 4,
+  data: {
+    hpPct: 40
+  }
+}, {
+  title: '夜兰被动：Q持续过程中满层Buff下提高伤害50%',
+  data: {
+    dmg: ({ params }) => params.q ? 50 : 0
+  }
+}, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, 'vaporize']

--- a/resources/meta/character/夜兰/calc_teamC6R5.js
+++ b/resources/meta/character/夜兰/calc_teamC6R5.js
@@ -1,0 +1,86 @@
+export const details = [ {
+  title: '夜万莫香E络命丝伤害',
+  dmg: ({ talent, attr, calc }, { basic }) => basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e')
+
+}, {
+  title: '夜万莫香E络命丝蒸发',
+  dmg: ({ talent, attr, calc }, { basic }) => basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e', '蒸发')
+
+}, {
+  
+  title: '夜万莫香Q协同单段伤害',
+  params: { q: true },
+  dmg: ({ talent, attr, calc, cons }, { basic }) => {
+    return basic(calc(attr.hp) * (talent.q['玄掷玲珑伤害'] / 3 / 100), 'q')
+  }
+}, {
+  check: ({ cons }) => cons < 6,
+  dmgKey: 'q',
+  title: 'EE双蒸后台8次连携',
+  params: { q: true },
+  dmg: ({ talent, attr, calc, cons }, { basic }) => {
+    let e_v = basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e', '蒸发')
+    let erming = basic(calc(attr.hp) * (14 / 100), 'q')
+    let count = cons * 1 >= 2 ? 1 : 0
+    let q = basic(calc(attr.hp) * (talent.q['玄掷玲珑伤害'] / 3 / 100), 'q',)
+    return {
+        dmg: 2 * e_v.dmg + 4 * erming.dmg * count+ 24 * q.dmg,
+        avg: 2 * e_v.avg + 4 * erming.avg * count+ 24 * q.avg
+    }
+  }
+}, {
+  check: ({ cons }) => cons >= 6,
+  dmgKey: 'q',
+  title: '6命EaEaaaa双蒸',
+  params: { q: true },
+  dmg: ({ talent, attr, calc, cons }, { basic }) => {
+    let e_v = basic(calc(attr.hp) * talent.e['技能伤害'] / 100, 'e', '蒸发')
+    let erming = basic(calc(attr.hp) * (14 / 100), 'q')
+    let q = basic(calc(attr.hp) * (talent.q['玄掷玲珑伤害'] / 3 / 100), 'q',)
+    let a = basic(calc(attr.hp) * talent.a['破局矢伤害']*1.56 / 100, 'a2')
+    return {
+        dmg: 2*e_v.dmg + 2*erming.dmg+ 15*q.dmg+ 5*a.dmg,
+        avg: 2*e_v.avg + 2*erming.avg+ 15*q.avg+ 5*a.avg
+    }
+  }
+}]
+
+export const defDmgKey = 'q'
+export const mainAttr = 'hp,cpct,cdmg'
+
+export const buffs = [{
+  title: '夜兰被动：有4个不同元素类型角色时，夜兰生命值上限提高30%',
+  data: {
+    hpPct: 30
+  }
+}, {
+  title: '夜兰4命：E络命丝爆发提高生命值，满Buff下提高40%',
+  cons: 4,
+  data: {
+    hpPct: 40
+  }
+}, {
+  title: '夜兰被动：Q持续过程中满层Buff下提高伤害50%',
+  data: {
+    dmg: ({ params }) => params.q ? 50 : 0
+  }
+}, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, {
+    title: '千夜教官满命莫娜：获得[dmg]%增伤，双水,暴击[cpct]%,精通[mastery]',
+    data: {
+      dmg: 60,
+      hpPct: 25,
+      cpct:15,
+      mastery:168
+   }
+  }, 'vaporize']

--- a/resources/meta/character/宵宫/calc_teamC0R1.js
+++ b/resources/meta/character/宵宫/calc_teamC0R1.js
@@ -1,0 +1,98 @@
+export const details = [{
+  title: '宵夜万班首段普攻',
+  params: { num: 1 },
+  dmg: ({ talent }, dmg) => dmg(talent.a['一段伤害'], 'a')
+}, {
+  title: '宵夜万班普攻尾箭',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) => dmg(talent.a['五段伤害'], 'a')
+}, {
+  title: '宵夜万班尾箭蒸发',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) => dmg(talent.a['五段伤害'], 'a', 'vaporize')
+}, {
+  check: ({ cons }) => cons >= 6,
+  dmgKey: 'e',
+  title: '宵夜万班凹双蒸',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) =>{
+  let a0Dmg = dmg(talent.a['一段伤害']/2, 'a', 'vaporize')
+  let a1Dmg = dmg(talent.a['一段伤害']/2, 'a')
+  let a1_5Dmg = dmg(talent.a['一段伤害']/2, 'a')
+  let a2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a3Dmg = dmg(talent.a['三段伤害'], 'a', 'vaporize')
+  let a4Dmg = dmg(talent.a['四段伤害'], 'a')
+  let a4_5Dmg = dmg(talent.a['四段伤害']/2, 'a')
+  let a5Dmg = dmg(talent.a['五段伤害'], 'a', 'vaporize')
+  let a5_5Dmg = dmg(talent.a['五段伤害']/2, 'a', 'vaporize')
+  return {
+      avg: a0Dmg.avg + a1Dmg.avg+ a1_5Dmg.avg+ a2Dmg.avg+ a3Dmg.avg+ 3 * a4_5Dmg.avg+ a5_5Dmg.avg+ a5Dmg.avg,
+      dmg: a0Dmg.dmg + a1Dmg.dmg +a1_5Dmg.dmg + a2Dmg.dmg + a3Dmg.dmg + 3 * a4_5Dmg.dmg+ a5_5Dmg.dmg + a5Dmg.dmg
+    }
+  }
+}, {
+  check: ({ cons }) => cons < 6,
+  dmgKey: 'e',
+  title: '宵夜万班147蒸发',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) =>{
+  let a0Dmg = dmg(talent.a['一段伤害'], 'a', 'vaporize')
+  let a1Dmg = dmg(talent.a['一段伤害'], 'a')
+  let a2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a3Dmg = dmg(talent.a['三段伤害'], 'a', 'vaporize')
+  let a4Dmg = dmg(talent.a['四段伤害'], 'a')
+  let a5Dmg = dmg(talent.a['一段伤害'], 'a', 'vaporize')
+  return {
+      avg: a0Dmg.avg/2 + a1Dmg.avg/2+ a2Dmg.avg+ a3Dmg.avg+ a4Dmg.avg+ a5Dmg.avg,
+      dmg: a0Dmg.dmg/2 + a1Dmg.dmg/2 + a2Dmg.dmg + a3Dmg.dmg + a4Dmg.dmg + a5Dmg.dmg
+    }
+  }
+}]
+
+export const defDmgKey = 'e'
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+  title: '焰硝庭火舞：开启E后额外提升普通[aMulti]%伤害',
+  data: {
+    aMulti: ({ talent }) => talent.e['炽焰箭伤害'] - 100
+  }
+}, {
+  title: '宵宫被动：袖火百景图10层提高20%火伤加成',
+  data: {
+    dmg: ({ params }) => params.num ? params.num * 2 : 20
+  }
+}, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, {
+    title: '夜兰：获得[dmg]%增伤',
+    data: {
+      dmg: 35
+   }
+  }, {
+  title: '宵宫2命：宵宫造成暴击后获得25%火伤加成',
+  cons: 2,
+  data: {
+    dmg: ({ params }) => params.num > 1 ? 25 : 0
+  }
+},{
+  title: '宵宫6命：加特林（以1.3倍折合）',
+  cons: 6,
+  data: {
+    aMulti: 0
+  }
+}, 'vaporize']

--- a/resources/meta/character/宵宫/calc_teamC6R5.js
+++ b/resources/meta/character/宵宫/calc_teamC6R5.js
@@ -1,0 +1,99 @@
+export const details = [{
+  title: '宵夜万班首段普攻',
+  params: { num: 1 },
+  dmg: ({ talent }, dmg) => dmg(talent.a['一段伤害'], 'a')
+}, {
+  title: '宵夜万班普攻尾箭',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) => dmg(talent.a['五段伤害'], 'a')
+}, {
+  title: '宵夜万班尾箭蒸发',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) => dmg(talent.a['五段伤害'], 'a', 'vaporize')
+}, {
+  check: ({ cons }) => cons >= 6,
+  dmgKey: 'e',
+  title: '宵夜万班凹双蒸',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) =>{
+  let a0Dmg = dmg(talent.a['一段伤害']/2, 'a', 'vaporize')
+  let a1Dmg = dmg(talent.a['一段伤害']/2, 'a')
+  let a1_5Dmg = dmg(talent.a['一段伤害']/2, 'a')
+  let a2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a3Dmg = dmg(talent.a['三段伤害'], 'a', 'vaporize')
+  let a4Dmg = dmg(talent.a['四段伤害'], 'a')
+  let a4_5Dmg = dmg(talent.a['四段伤害']/2, 'a')
+  let a5Dmg = dmg(talent.a['五段伤害'], 'a', 'vaporize')
+  let a5_5Dmg = dmg(talent.a['五段伤害']/2, 'a', 'vaporize')
+  return {
+      avg: a0Dmg.avg + a1Dmg.avg+ a1_5Dmg.avg+ a2Dmg.avg+ a3Dmg.avg+ 3 * a4_5Dmg.avg+ a5_5Dmg.avg+ a5Dmg.avg,
+      dmg: a0Dmg.dmg + a1Dmg.dmg +a1_5Dmg.dmg + a2Dmg.dmg + a3Dmg.dmg + 3 * a4_5Dmg.dmg+ a5_5Dmg.dmg + a5Dmg.dmg
+    }
+  }
+}, {
+  check: ({ cons }) => cons < 6,
+  dmgKey: 'e',
+  title: '宵夜万班147蒸发',
+  params: { num: 10 },
+  dmg: ({ talent }, dmg) =>{
+  let a0Dmg = dmg(talent.a['一段伤害'], 'a', 'vaporize')
+  let a1Dmg = dmg(talent.a['一段伤害'], 'a')
+  let a2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a3Dmg = dmg(talent.a['三段伤害'], 'a', 'vaporize')
+  let a4Dmg = dmg(talent.a['四段伤害'], 'a')
+  let a5Dmg = dmg(talent.a['一段伤害'], 'a', 'vaporize')
+  return {
+      avg: a0Dmg.avg/2 + a1Dmg.avg/2+ a2Dmg.avg+ a3Dmg.avg+ a4Dmg.avg+ a5Dmg.avg,
+      dmg: a0Dmg.dmg/2 + a1Dmg.dmg/2 + a2Dmg.dmg + a3Dmg.dmg + a4Dmg.dmg + a5Dmg.dmg
+    }
+  }
+}]
+
+export const defDmgKey = 'e'
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+  title: '焰硝庭火舞：开启E后额外提升普通[aMulti]%伤害',
+  data: {
+    aMulti: ({ talent }) => talent.e['炽焰箭伤害'] - 100
+  }
+}, {
+  title: '宵宫被动：袖火百景图10层提高20%火伤加成',
+  data: {
+    dmg: ({ params }) => params.num ? params.num * 2 : 20
+  }
+}, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, {
+    title: '夜兰：获得[dmg]%增伤',
+    data: {
+      dmg: 35
+   }
+  }, {
+  title: '宵宫2命：宵宫造成暴击后获得25%火伤加成',
+  cons: 2,
+  data: {
+    dmg: ({ params }) => params.num > 1 ? 25 : 0
+  }
+},{
+  title: '宵宫6命：加特林（以1.3倍折合）',
+  cons: 6,
+  data: {
+    aMulti: 0
+  }
+}, 'vaporize']

--- a/resources/meta/character/提纳里/calc_teamC0R1.js
+++ b/resources/meta/character/提纳里/calc_teamC0R1.js
@@ -1,0 +1,96 @@
+export const details = [{
+  title: '提万妲花筥箭激化伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['花筥箭伤害'], 'a2', '超激化')
+}, {
+  title: '提万妲单支藏蕴花矢伤害',
+  dmg: ({ talent, cons }, dmg) => dmg(talent.a['藏蕴花矢伤害'], 'a2')
+}, {
+  title: '提万妲二段重击总伤害',
+  dmg: ({ talent, cons }, dmg) => {
+    let d1 = dmg(talent.a['花筥箭伤害'], 'a2')
+    let d2 = dmg(talent.a['藏蕴花矢伤害'], 'a2')
+    let count = cons * 1 === 6 ? 5 : 4
+    return {
+      dmg: d1.dmg + d2.dmg * count,
+      avg: d1.avg + d2.avg * count
+    }
+  }
+}, {
+  title: '提万妲Q总伤害',
+  params: { q: true },
+  dmg: ({ talent, cons }, dmg) => {
+    return dmg(talent.q['缠藤箭伤害'] * 6 + talent.q['次级缠藤箭伤害'] * 6, 'q')
+  }
+}, {
+  title: '提万妲eQ3e3a总激化伤害',
+  params: { q: true },
+  dmg: ({ talent, cons }, dmg) => {
+    let d1 = dmg(talent.a['花筥箭伤害'], 'a2', '超激化')
+    let d2 = dmg(talent.a['藏蕴花矢伤害'], 'a2')
+    let d3 = dmg(talent.a['藏蕴花矢伤害'], 'a2', '超激化')
+    let q1 = dmg(talent.q['缠藤箭伤害'] , 'q', '超激化')
+    let q2 = dmg(talent.q['缠藤箭伤害'] , 'q')
+    let q3 = dmg(talent.q['次级缠藤箭伤害'] , 'q', '超激化')
+    let q4 = dmg(talent.q['次级缠藤箭伤害'] , 'q')
+    let count = cons * 1 === 6 ? 4 : 2
+    return {
+      dmg: 3*(d1.dmg * count + d2.dmg * 6 + d3.dmg * 2) + q1.dmg * 2+ q2.dmg * 4+ q3.dmg * 2+ q4.dmg * 4,
+      avg: 3*(d1.avg * count + d2.avg * 6 + d3.avg * 2) + q1.avg * 2+ q2.avg * 4+ q3.avg * 2+ q4.avg * 4
+    }
+  }
+}]
+
+// 10144 6794&10596
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+export const defDmgIdx = 4
+export const buffs = [{
+  title: '提纳里被动：发射花筥箭后，元素精通提升50点',
+  data: {
+    mastery: 50,
+    qMastery: 0
+  }
+}, {
+  title: '提纳里被动：基于元素精通提升重击及Q伤害[a2Dmg]%',
+  sort: 5,
+  data: {
+    a2Dmg: ({ calc, attr }) => Math.min(80, calc(attr.mastery) * 0.08),
+    qDmg: ({ calc, attr }) => Math.min(80, calc(attr.mastery) * 0.08)
+  }
+}, {
+  title: '提纳里1命：重击暴击率提高15%',
+  cons: 1,
+  data: {
+    a2Cpct: 15
+  }
+}, {
+  title: '提纳里2命：E范围中存在敌人时，获得20%草伤加成',
+  cons: 2,
+  data: {
+    dmg: 20
+  }
+}, {
+  title: '提纳里4命：释放Q时提高元素精通60，触发反应进一步提升60',
+  cons: 4,
+  data: {
+    mastery: ({ params }) => params.q ? 120 : 0
+  }
+}, {
+  title: '提纳里6命：花筥箭在命中后能产生1枚额外的藏蕴花矢',
+  cons: 6
+},{
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, {
+    title: '精1千夜纳西妲：增加精通[mastery]（包括双草）,减抗[kx]%',
+    data: {
+      mastery: 390,
+      kx:30
+   }
+  }]

--- a/resources/meta/character/提纳里/calc_teamC6R5.js
+++ b/resources/meta/character/提纳里/calc_teamC6R5.js
@@ -1,0 +1,96 @@
+export const details = [{
+  title: '提万妲花筥箭激化伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['花筥箭伤害'], 'a2', '超激化')
+}, {
+  title: '提万妲单支藏蕴花矢伤害',
+  dmg: ({ talent, cons }, dmg) => dmg(talent.a['藏蕴花矢伤害'], 'a2')
+}, {
+  title: '提万妲二段重击总伤害',
+  dmg: ({ talent, cons }, dmg) => {
+    let d1 = dmg(talent.a['花筥箭伤害'], 'a2')
+    let d2 = dmg(talent.a['藏蕴花矢伤害'], 'a2')
+    let count = cons * 1 === 6 ? 5 : 4
+    return {
+      dmg: d1.dmg + d2.dmg * count,
+      avg: d1.avg + d2.avg * count
+    }
+  }
+}, {
+  title: '提万妲Q总伤害',
+  params: { q: true },
+  dmg: ({ talent, cons }, dmg) => {
+    return dmg(talent.q['缠藤箭伤害'] * 6 + talent.q['次级缠藤箭伤害'] * 6, 'q')
+  }
+}, {
+  title: '提万妲eQ3e3a总激化伤害',
+  params: { q: true },
+  dmg: ({ talent, cons }, dmg) => {
+    let d1 = dmg(talent.a['花筥箭伤害'], 'a2', '超激化')
+    let d2 = dmg(talent.a['藏蕴花矢伤害'], 'a2')
+    let d3 = dmg(talent.a['藏蕴花矢伤害'], 'a2', '超激化')
+    let q1 = dmg(talent.q['缠藤箭伤害'] , 'q', '超激化')
+    let q2 = dmg(talent.q['缠藤箭伤害'] , 'q')
+    let q3 = dmg(talent.q['次级缠藤箭伤害'] , 'q', '超激化')
+    let q4 = dmg(talent.q['次级缠藤箭伤害'] , 'q')
+    let count = cons * 1 === 6 ? 4 : 2
+    return {
+      dmg: 3*(d1.dmg * count + d2.dmg * 6 + d3.dmg * 2) + q1.dmg * 2+ q2.dmg * 4+ q3.dmg * 2+ q4.dmg * 4,
+      avg: 3*(d1.avg * count + d2.avg * 6 + d3.avg * 2) + q1.avg * 2+ q2.avg * 4+ q3.avg * 2+ q4.avg * 4
+    }
+  }
+}]
+
+// 10144 6794&10596
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+export const defDmgIdx = 4
+export const buffs = [{
+  title: '提纳里被动：发射花筥箭后，元素精通提升50点',
+  data: {
+    mastery: 50,
+    qMastery: 0
+  }
+}, {
+  title: '提纳里被动：基于元素精通提升重击及Q伤害[a2Dmg]%',
+  sort: 5,
+  data: {
+    a2Dmg: ({ calc, attr }) => Math.min(80, calc(attr.mastery) * 0.08),
+    qDmg: ({ calc, attr }) => Math.min(80, calc(attr.mastery) * 0.08)
+  }
+}, {
+  title: '提纳里1命：重击暴击率提高15%',
+  cons: 1,
+  data: {
+    a2Cpct: 15
+  }
+}, {
+  title: '提纳里2命：E范围中存在敌人时，获得20%草伤加成',
+  cons: 2,
+  data: {
+    dmg: 20
+  }
+}, {
+  title: '提纳里4命：释放Q时提高元素精通60，触发反应进一步提升60',
+  cons: 4,
+  data: {
+    mastery: ({ params }) => params.q ? 120 : 0
+  }
+}, {
+  title: '提纳里6命：花筥箭在命中后能产生1枚额外的藏蕴花矢',
+  cons: 6
+},{
+    title: '精5苍古万叶：苍古普攻重击32增伤，增加[atkPct]%攻击,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      atkPct:40,
+      mastery:200
+   }
+  }, {
+    title: '精5千夜纳西妲：增加精通[mastery]（包括双草）,减防[enemyDef]%,减抗[kx]%',
+    data: {
+      mastery: 398,
+      enemyDef: 30,
+      kx:30
+   }
+  }]

--- a/resources/meta/character/甘雨/calc_teamC0R1.js
+++ b/resources/meta/character/甘雨/calc_teamC0R1.js
@@ -1,0 +1,61 @@
+export const details = [{
+  title: '甘鹤万班蓄力总伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['霜华矢·霜华绽发伤害'] + talent.a['霜华矢命中伤害'], 'a2')
+}, {
+  title: '甘鹤万班蓄力融化',
+  dmg: ({ talent }, dmg) => dmg(talent.a['霜华矢·霜华绽发伤害'] + talent.a['霜华矢命中伤害'], 'a2', 'melt')
+}, {
+  title: 'Q单个冰凌伤害',
+  params: {
+    q: 1
+  },
+  dmg: ({ talent }, dmg) => dmg(talent.q['冰棱伤害'], 'q')
+}]
+
+export const defDmgIdx = 1
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+  cons: 0,
+  title: '甘雨被动：霜华矢发射后的5秒内霜华矢暴击率提高20%',
+  data: {
+    a2Cpct: 20
+  }
+}, {
+  cons: 1,
+  title: '甘雨1命：霜华失命中减少敌人15%冰抗',
+  data: {
+    kx: ({ params }) => params.q ? 0 : 15
+  }
+}, {
+  cons: 4,
+  title: '甘雨4命：大招领域内敌人受到的伤害提升25%',
+  data: {
+    dmg: ({ params }) => params.q ? 25 : 0
+  }
+}, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, {
+    title: '精1息灾申鹤：获得[dmg]%增伤,减抗[kx]%,提升冰伤害4100',
+    data: {
+      dmg: 30,
+      kx:15,
+      a2Plus:4100*2,
+      ePlus:4100,
+      qPlus:4100
+   }
+  },{
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, 'melt']

--- a/resources/meta/character/甘雨/calc_teamC6R5.js
+++ b/resources/meta/character/甘雨/calc_teamC6R5.js
@@ -1,0 +1,63 @@
+export const details = [{
+  title: '甘鹤万班蓄力总伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['霜华矢·霜华绽发伤害'] + talent.a['霜华矢命中伤害'], 'a2')
+}, {
+  title: '甘鹤万班蓄力融化',
+  dmg: ({ talent }, dmg) => dmg(talent.a['霜华矢·霜华绽发伤害'] + talent.a['霜华矢命中伤害'], 'a2', 'melt')
+}, {
+  title: 'Q单个冰凌伤害',
+  params: {
+    q: 1
+  },
+  dmg: ({ talent }, dmg) => dmg(talent.q['冰棱伤害'], 'q')
+}]
+
+export const defDmgIdx = 1
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+  cons: 0,
+  title: '甘雨被动：霜华矢发射后的5秒内霜华矢暴击率提高20%',
+  data: {
+    a2Cpct: 20
+  }
+}, {
+  cons: 1,
+  title: '甘雨1命：霜华失命中减少敌人15%冰抗',
+  data: {
+    kx: ({ params }) => params.q ? 0 : 15
+  }
+}, {
+  cons: 4,
+  title: '甘雨4命：大招领域内敌人受到的伤害提升25%',
+  data: {
+    dmg: ({ params }) => params.q ? 25 : 0
+  }
+}, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, {
+    title: '精5息灾申鹤：获得[dmg]%增伤,减抗[kx]%,爆伤15%,提升冰伤害5700',
+    data: {
+      dmg: 30,
+      kx:15,
+      cdmg:15,
+      a2Plus:5700*2,
+      ePlus:5700,
+      qPlus:5700
+   }
+  },{
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, 'melt']

--- a/resources/meta/character/神里绫人/calc_teamC0R1.js
+++ b/resources/meta/character/神里绫人/calc_teamC0R1.js
@@ -1,0 +1,56 @@
+export const details = [{
+  title: '绫夜万班瞬水剑三段伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['三段瞬水剑伤害'], 'a')
+}, {
+  title: '绫夜万班瞬水剑三段蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.e['三段瞬水剑伤害'], 'a', 'vaporize')
+}, {
+  title: '绫夜万班Q每段伤害',
+  params: { q: 1 },
+  dmg: ({ talent }, dmg) => dmg(talent.q['水花剑伤害'], 'q')
+}]
+
+export const defDmgIdx = 1
+export const mainAttr = 'hp,atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+  cons: 2,
+  title: '绫人2命：3层浪闪以上时提高50%生命值',
+  data: {
+    hpPct: ({ params }) => params.q ? 0 : 50
+  }
+}, {
+  check: ({ cons }) => cons < 2,
+  title: '4层浪闪：提高瞬水剑伤害[aPlus]',
+  data: {
+    aPlus: ({ attr, calc, talent }) => calc(attr.hp) * talent.e['浪闪伤害值提高'] / 100 * 4
+  }
+}, {
+  cons: 2,
+  title: '绫人2命：5层浪闪提高瞬水剑伤害[aPlus]',
+  data: {
+    aPlus: ({ attr, calc, talent }) => calc(attr.hp) * talent.e['浪闪伤害值提高'] / 100 * 5
+  }
+}, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, {
+    title: '夜兰：获得[dmg]%增伤,双水25%生命值',
+    data: {
+      dmg: 35,
+      hpPct:25
+   }
+  }, 'vaporize']

--- a/resources/meta/character/神里绫人/calc_teamC6R5.js
+++ b/resources/meta/character/神里绫人/calc_teamC6R5.js
@@ -1,0 +1,57 @@
+export const details = [{
+  title: '绫夜万班瞬水剑三段伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['三段瞬水剑伤害'], 'a')
+}, {
+  title: '绫夜万班瞬水剑三段蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.e['三段瞬水剑伤害'], 'a', 'vaporize')
+}, {
+  title: '绫夜万班Q每段伤害',
+  params: { q: 1 },
+  dmg: ({ talent }, dmg) => dmg(talent.q['水花剑伤害'], 'q')
+}]
+
+export const defDmgIdx = 1
+export const mainAttr = 'hp,atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+  cons: 2,
+  title: '绫人2命：3层浪闪以上时提高50%生命值',
+  data: {
+    hpPct: ({ params }) => params.q ? 0 : 50
+  }
+}, {
+  check: ({ cons }) => cons < 2,
+  title: '4层浪闪：提高瞬水剑伤害[aPlus]',
+  data: {
+    aPlus: ({ attr, calc, talent }) => calc(attr.hp) * talent.e['浪闪伤害值提高'] / 100 * 4
+  }
+}, {
+  cons: 2,
+  title: '绫人2命：5层浪闪提高瞬水剑伤害[aPlus]',
+  data: {
+    aPlus: ({ attr, calc, talent }) => calc(attr.hp) * talent.e['浪闪伤害值提高'] / 100 * 5
+  }
+}, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, {
+    title: '夜兰：获得[dmg]%增伤,[hpPct]%生命值,双水25%生命值',
+    data: {
+      dmg: 35,
+      hpPct:65
+   }
+  }, 'vaporize']

--- a/resources/meta/character/神里绫华/calc_teamC0R1.js
+++ b/resources/meta/character/神里绫华/calc_teamC0R1.js
@@ -1,0 +1,65 @@
+export const details = [{
+  title: '神鹤万莫重击总伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+}, {
+  title: '神鹤万莫E伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+}, {
+  title: '神鹤万莫Q单段伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['切割伤害'], 'q')
+}]
+
+export const mainAttr = 'atk,cpct,cdmg'
+export const defDmgIdx = 2
+
+export const buffs = [{
+  passive: 1,
+  title: '神里被动：释放E后普攻与重击伤害提高30%',
+  data: {
+    aDmg: 30,
+    a2Dmg: 30
+  }
+}, {
+  passive: 2,
+  title: '神里被动：霰步命中敌人获得18%冰伤加成',
+  data: {
+    dmg: 18
+  }
+}, {
+  cons: 4,
+  title: '神里4命：元素爆发后敌人防御力降低30%',
+  data: {
+    qDef: 30
+  }
+}, {
+  cons: 6,
+  title: '神里6命：每10秒重击伤害提高[a2Dmg]%',
+  data: {
+    a2Dmg: 298
+  }
+}, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, {
+    title: '精1息灾申鹤：获得[dmg]%增伤,减抗[kx]%,提升冰伤害4100',
+    data: {
+      dmg: 30,
+      kx:15,
+      a2Plus:4100*3,
+      ePlus:4100,
+      qPlus:4100
+   }
+  }, {
+    title: '千岩讨龙莫娜：获得[dmg]%增伤，增加[atkPct]%攻击',
+    data: {
+      dmg: 60,
+      atkPct:68,
+   }
+  }]

--- a/resources/meta/character/神里绫华/calc_teamC6R5.js
+++ b/resources/meta/character/神里绫华/calc_teamC6R5.js
@@ -1,0 +1,70 @@
+export const details = [{
+  title: '神鹤万莫重击总伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+}, {
+  title: '神鹤万莫E伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+}, {
+  title: '神鹤万莫Q单段伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['切割伤害'], 'q')
+}]
+
+export const mainAttr = 'atk,cpct,cdmg'
+export const defDmgIdx = 2
+
+export const buffs = [{
+  passive: 1,
+  title: '神里被动：释放E后普攻与重击伤害提高30%',
+  data: {
+    aDmg: 30,
+    a2Dmg: 30
+  }
+}, {
+  passive: 2,
+  title: '神里被动：霰步命中敌人获得18%冰伤加成',
+  data: {
+    dmg: 18
+  }
+}, {
+  cons: 4,
+  title: '神里4命：元素爆发后敌人防御力降低30%',
+  data: {
+    qDef: 30
+  }
+}, {
+  cons: 6,
+  title: '神里6命：每10秒重击伤害提高[a2Dmg]%',
+  data: {
+    a2Dmg: 298
+  }
+}, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, {
+    title: '精5息灾宗室申鹤：获得[dmg]%增伤，增加[atkPct]%攻击,减抗[kx]%,爆伤15%,提升冰伤害5700,双冰暴击15%',
+    data: {
+      dmg: 30,
+      atkPct:20,
+      kx:15,
+      cpct: 15,
+      cdmg:15,
+      a2Plus:5700*3,
+      ePlus:5700,
+      qPlus:5700
+   }
+  }, {
+    title: '千岩讨龙莫娜：获得[dmg]%增伤，增加[atkPct]%攻击,暴击15%',
+    data: {
+      dmg: 60,
+      cpct: 15,
+      atkPct:68,
+   }
+  }]

--- a/resources/meta/character/达达利亚/calc_teamC0R1.js
+++ b/resources/meta/character/达达利亚/calc_teamC0R1.js
@@ -1,0 +1,34 @@
+export const details = [{
+  title: '万达开E后重击',
+  dmg: ({ talent }, dmg) => dmg(talent.e['重击伤害'], 'a2')
+}, {
+  title: '万达断流·斩 伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['断流·斩 伤害'], 'e')
+}, {
+  title: '万达开E后Q伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害·近战'], 'q')
+}, {
+  title: '万达开E后Q蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害·近战'], 'q', 'vaporize')
+}]
+
+export const defDmgIdx = 3
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  },'vaporize']

--- a/resources/meta/character/达达利亚/calc_teamC6R5.js
+++ b/resources/meta/character/达达利亚/calc_teamC6R5.js
@@ -1,0 +1,35 @@
+export const details = [{
+  title: '万达开E后重击',
+  dmg: ({ talent }, dmg) => dmg(talent.e['重击伤害'], 'a2')
+}, {
+  title: '万达断流·斩 伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['断流·斩 伤害'], 'e')
+}, {
+  title: '万达开E后Q伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害·近战'], 'q')
+}, {
+  title: '万达开E后Q蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害·近战'], 'q', 'vaporize')
+}]
+
+export const defDmgIdx = 3
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  },'vaporize']

--- a/resources/meta/character/雷电将军/calc_teamC0R1.js
+++ b/resources/meta/character/雷电将军/calc_teamC0R1.js
@@ -1,0 +1,81 @@
+export const details = [{
+  title: '雷九八万满愿力Q首刀',
+  params: {
+    type: 0,
+    num: 60,
+    ban: 0
+  },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['梦想一刀基础伤害'], 'q')
+}, {
+  title: '雷九万班满愿力Q首刀',
+  params: {
+    type: 0,
+    num: 60,
+    ban: 1
+  },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['梦想一刀基础伤害'], 'q')
+}, {
+  title: '雷九万班满愿力重击',
+  params: {
+    type: 1,
+    num: 60,
+    ban: 1
+  },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['重击伤害'], 'q')
+}]
+
+export const defParams = {
+  ban: 1,
+  num: 60,
+  type: 0
+}
+
+export const defDmgIdx = 0
+export const mainAttr = 'atk,cpct,cdmg,recharge,mastery'
+
+export const buffs = [
+  {
+    title: '恶曜开眼：开E元素爆发伤害提升[qDmg]%',
+    data: {
+      qDmg: ({ talent }) => talent.e['元素爆发伤害提高'] * 90
+    }
+  }, {
+    title: '梦想真说：Q满愿力获得[qPct]%大招倍率加成',
+    data: {
+      qPct: ({ talent, params }) => talent.q['愿力加成'][params.type || 0] * params.num
+    }
+  }, {
+    check: ({ cons }) => cons >= 2,
+    title: '雷神2命：大招无视敌人[qIgnore]%防御力',
+    data: {
+      qIgnore: 60
+    }
+  }, {
+    title: '雷神被动：基于元素充能获得[dmg]%雷伤加成',
+    data: {
+      dmg: ({ attr }) => Math.max(attr.recharge.base + attr.recharge.plus - 100, 0) * 0.4
+    }
+  }, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: ({ params }) =>20 * params.ban,
+      atkPlus: ({ params }) =>1202.35 * params.ban
+  }
+  }, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, {
+    title: '天空九条：增加[atkPlus]点攻击力与[cdmg]%爆伤',
+    data: {
+      atkPlus: 794.2,
+      cdmg:60,
+   }
+  }
+      ]

--- a/resources/meta/character/雷电将军/calc_teamC6R5.js
+++ b/resources/meta/character/雷电将军/calc_teamC6R5.js
@@ -1,0 +1,88 @@
+export const details = [{
+  title: '雷九八万满愿力Q首刀',
+  params: {
+    type: 0,
+    num: 60,
+    ban: 0
+  },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['梦想一刀基础伤害'], 'q')
+}, {
+  title: '雷九万班满愿力Q首刀',
+  params: {
+    type: 0,
+    num: 60,
+    ban: 1
+  },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['梦想一刀基础伤害'], 'q')
+}, {
+  title: '雷九万班满愿力重击',
+  params: {
+    type: 1,
+    num: 60,
+    ban: 1
+  },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['重击伤害'], 'q')
+}]
+
+export const defParams = {
+  ban: 1,
+  num: 60,
+  type: 0
+}
+
+export const defDmgIdx = 0
+export const mainAttr = 'atk,cpct,cdmg,recharge,mastery'
+
+export const buffs = [
+  {
+    title: '恶曜开眼：开E元素爆发伤害提升[qDmg]%',
+    data: {
+      qDmg: ({ talent }) => talent.e['元素爆发伤害提高'] * 90
+    }
+  }, {
+    title: '梦想真说：Q满愿力获得[qPct]%大招倍率加成',
+    data: {
+      qPct: ({ talent, params }) => talent.q['愿力加成'][params.type || 0] * params.num
+    }
+  }, {
+    check: ({ cons }) => cons >= 2,
+    title: '雷神2命：大招无视敌人[qIgnore]%防御力',
+    data: {
+      qIgnore: 60
+    }
+  }, {
+    title: '雷神被动：基于元素充能获得[dmg]%雷伤加成',
+    data: {
+      dmg: ({ attr }) => Math.max(attr.recharge.base + attr.recharge.plus - 100, 0) * 0.4
+    }
+  }, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: ({ params }) =>20 * params.ban,
+      atkPlus: ({ params }) =>1202.35 * params.ban
+  }
+  }, {
+    title: '八重4命：增加20%雷伤',
+    data: {
+      dmg: ({ params }) =>20 * (1 - params.ban)
+  }
+  }, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, {
+    title: '教官天空九条：增加[atkPlus]点攻击力与[cdmg]%爆伤,精通[mastery]',
+    data: {
+      atkPlus: 794.2,
+      cdmg:60,
+      mastery:120
+   }
+  }
+      ]

--- a/resources/meta/character/香菱/calc_teamC0R1.js
+++ b/resources/meta/character/香菱/calc_teamC0R1.js
@@ -1,0 +1,40 @@
+export const details = [{
+  title: '万达锅巴单口伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['喷火伤害'], 'e')
+}, {
+  title: '万达锅巴单口蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.e['喷火伤害'], 'e', 'vaporize')
+}, {
+  title: '万达旋火轮单次伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['旋火轮伤害'], 'q')
+}, {
+  title: '万达旋火轮单次蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.q['旋火轮伤害'], 'q', 'vaporize')
+}]
+
+export const defDmgIdx = 3
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const buffs = [{
+  cons: 1,
+  title: '香菱1命：锅巴降低敌人火抗15',
+  data: {
+    kx: 15
+  }
+}, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40
+   }
+  }, 'vaporize']

--- a/resources/meta/character/香菱/calc_teamC6R5.js
+++ b/resources/meta/character/香菱/calc_teamC6R5.js
@@ -1,0 +1,41 @@
+export const details = [{
+  title: '万达锅巴单口伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['喷火伤害'], 'e')
+}, {
+  title: '万达锅巴单口蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.e['喷火伤害'], 'e', 'vaporize')
+}, {
+  title: '万达旋火轮单次伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['旋火轮伤害'], 'q')
+}, {
+  title: '万达旋火轮单次蒸发',
+  dmg: ({ talent }, dmg) => dmg(talent.q['旋火轮伤害'], 'q', 'vaporize')
+}]
+
+export const defDmgIdx = 3
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const buffs = [{
+  cons: 1,
+  title: '香菱1命：锅巴降低敌人火抗15',
+  data: {
+    kx: 15
+  }
+}, {
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {
+    title: '精5苍古万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+      mastery:200
+   }
+  }, 'vaporize']


### PR DESCRIPTION
增加了两种不同氪度的队友伤害，0命精1与满命满精。
八重：雷八九温
刻晴：刻九万妲
夜兰：夜万 or 夜万莫香（增加连招伤害）
宵宫：宵夜万班（增加连招伤害）
提纳里：提纳万（增加连招伤害）
甘雨：甘鹤万班
绫人：绫夜万班
神里：神鹤万莫
雷神：雷九万班，雷九万八
香菱，公子：万达
