### PR TITLE
增加了胡桃、一斗、可莉的组队伤害计算，修复了八重组队计算的错误

### DIFF
--- a/resources/meta/character/八重神子/calc_auto.js
+++ b/resources/meta/character/八重神子/calc_auto.js
@@ -57,7 +57,7 @@ export const buffs = [{
     eDef: 60
   }
 }, {
-  check: ({ cons, params }) => ((cons < 6 && cons > 1) && params.team === true),
+  check: ({ cons, params }) => ((cons == 6) && params.team === true),
   title: '精5终末6命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
   data: {
     atkPct: 40,
@@ -65,7 +65,7 @@ export const buffs = [{
     mastery: 200
   }
 }, {
-  check: ({ cons, params }) => (cons >= 6 && params.team === true),
+  check: ({ cons, params }) => (cons <= 2 && params.team === true),
   title: '精1终末0命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
   data: {
     atkPct: 20,

--- a/resources/meta/character/八重神子/calc_auto.js
+++ b/resources/meta/character/八重神子/calc_auto.js
@@ -65,7 +65,7 @@ export const buffs = [{
     mastery: 200
   }
 }, {
-  check: ({ cons, params }) => (cons <= 2 && params.team === true),
+  check: ({ cons, params }) => (cons <= 5 && params.team === true),
   title: '精1终末0命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
   data: {
     atkPct: 20,

--- a/resources/meta/character/可莉/calc_auto.js
+++ b/resources/meta/character/可莉/calc_auto.js
@@ -1,0 +1,102 @@
+export const details = [{
+    title: 'E后带火花重击',
+    params: { q: false, team: false },
+    dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+  }, {
+    title: 'E后带火花重击蒸发',
+    params: { q: false, team: false },
+    dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2', 'vaporize')
+  }, {
+    title: '单次轰轰火花伤害',
+    params: { team: false },
+    dmg: ({ talent }, dmg) => dmg(talent.q['轰轰火花伤害'], 'q')
+  }, {
+    title: '可莉三火E后火花重击',
+    params: { q: false, team: true },
+    dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+  }, {
+    title: '可莉三火轰轰火花伤害',
+    params: { team: true },
+    dmg: ({ talent }, dmg) => dmg(talent.q['轰轰火花伤害'], 'q')
+  }
+  ]
+  
+  export const defDmgIdx = 1
+  export const mainAttr = 'atk,cpct,cdmg,mastery'
+  
+  export const defParams = {
+    team: true
+  }
+  
+  export const buffs = [{
+    title: '可莉天赋：爆裂火花使重击伤害提升50%',
+    data: {
+      a2Dmg: 50
+    }
+  }, {
+    title: '可莉2命：蹦蹦炸弹的诡雷会使敌人的防御力降低23%',
+    cons: 2,
+    data: {
+      enemyDef: 23
+    }
+  }, {
+    title: '可莉6命：释放轰轰火花后获得10%火元素伤害加成',
+    cons: 6,
+    data: {
+      dmg: ({ params }) => params.q === false ? 0 : 10
+    }
+  }, {
+    check: ({ params }) => params.team === true,
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    sort: 9,
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+    }
+  }, {
+    check: ({ params }) => params.team === true,
+    title: '香菱6命：增加[dmg]%火伤',
+    sort: 9,
+    data: {
+      dmg: 15
+    }
+  }, {
+    check: ({ cons, params }) => cons <= 1 && params.team === true,
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    sort: 9,
+    data: {
+      aDmg: 16,
+      a2Dmg: 16,
+      a3Dmg: 16,
+      dmg: 40,
+      atkPct: 20,
+      kx: 40
+    }
+  }, {
+    check: ({ cons, params }) => ((cons < 6 && cons > 1) && params.team === true),
+    title: '精1苍古2命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    sort: 9,
+    data: {
+      aDmg: 16,
+      a2Dmg: 16,
+      a3Dmg: 16,
+      dmg: 48,
+      atkPct: 20,
+      kx: 40,
+      mastery: 200
+    }
+  }, {
+    check: ({ cons, params }) => (cons >= 6 && params.team === true),
+    title: '精5苍古6命万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    sort: 9,
+    data: {
+      aDmg: 32,
+      a2Dmg: 32,
+      a3Dmg: 32,
+      dmg: 48,
+      atkPct: 40,
+      kx: 40,
+      mastery: 200
+    }
+  }, 'vaporize']
+  

--- a/resources/meta/character/胡桃/calc_auto.js
+++ b/resources/meta/character/胡桃/calc_auto.js
@@ -20,7 +20,7 @@ export const details = [{
     dmg: ({ talent, attr }, dmg) => dmg(talent.q['低血量时技能伤害'], 'q', 'vaporize')
   }]
   
-  export const defDmgIdx = 1
+  export const defDmgIdx = 2
   export const mainAttr = 'hp,atk,cpct,cdmg,mastery'
   
   export const defParams = {

--- a/resources/meta/character/胡桃/calc_auto.js
+++ b/resources/meta/character/胡桃/calc_auto.js
@@ -28,6 +28,12 @@ export const details = [{
   }
   
   export const buffs = [{
+    check: ({ params }) => params.team === true,
+    title: '双水共鸣：获得[hpPct]%生命值',
+    data: {
+      hpPct: 25
+    }
+  },{
     title: '蝶引来生：开E获得[atkPlus]点攻击力加成',
     data: {
       atkPlus: ({ talent, attr, calc }) => {

--- a/resources/meta/character/胡桃/calc_auto.js
+++ b/resources/meta/character/胡桃/calc_auto.js
@@ -1,0 +1,55 @@
+export const details = [{
+    title: '半血开E重击',
+    params: { team: false },
+    dmg: ({ talent, attr }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+  }, {
+    title: '半血开E重击蒸发',
+    params: { team: false },
+    dmg: ({ talent, attr }, dmg) => dmg(talent.a['重击伤害'], 'a2', 'vaporize')
+  }, {
+    title: '胡桃双水半血重击蒸发',
+    params: { team: true},
+    dmg: ({ talent, attr }, dmg) => dmg(talent.a['重击伤害'], 'a2', 'vaporize')
+  }, {
+    title: '半血开E后Q蒸发',
+    params: { team: false },
+    dmg: ({ talent, attr }, dmg) => dmg(talent.q['低血量时技能伤害'], 'q', 'vaporize')
+  }, {
+    title: '胡桃双水半血Q蒸发',
+    params: { team: true},
+    dmg: ({ talent, attr }, dmg) => dmg(talent.q['低血量时技能伤害'], 'q', 'vaporize')
+  }]
+  
+  export const defDmgIdx = 1
+  export const mainAttr = 'hp,atk,cpct,cdmg,mastery'
+  
+  export const defParams = {
+    team: true
+  }
+  
+  export const buffs = [{
+    title: '蝶引来生：开E获得[atkPlus]点攻击力加成',
+    data: {
+      atkPlus: ({ talent, attr, calc }) => {
+        return Math.min(talent.e['攻击力提高'] * calc(attr.hp) / 100, attr.atk.base * 4)
+      }
+    }
+  }, {
+    title: '胡桃被动：半血获得33%火伤加成',
+    data: {
+      dmg: 33
+    }
+  },{
+    check: ({ params }) => params.team === true,
+    title: '夜兰：获得平均[dmg]%增伤',
+    data: {
+      dmg: 35
+    }
+  },{
+    check: ({ params }) => params.team === true,
+    title: '钟离：降低敌人[kx]%全抗',
+    data: {
+      kx: 20
+    }
+  },'vaporize']
+  

--- a/resources/meta/character/荒泷一斗/calc_auto.js
+++ b/resources/meta/character/荒泷一斗/calc_auto.js
@@ -1,0 +1,71 @@
+export const details = [{
+    title: '开大后每段重击',
+    params: { team: false },
+    dmg: ({ talent }, dmg) => dmg(talent.a['荒泷逆袈裟连斩伤害'], 'a2')
+  }, {
+    title: '开大后重击尾段',
+    params: { team: false },
+    dmg: ({ talent }, dmg) => dmg(talent.a['荒泷逆袈裟终结伤害'], 'a2')
+  
+  }, {
+    title: '开大后牛牛伤害',
+    params: { team: false },
+    dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+  }, {
+    title: '一五钟开大重击',
+    params: { team: true },
+    dmg: ({ talent }, dmg) => dmg(talent.a['荒泷逆袈裟连斩伤害'], 'a2')
+  }, {
+    title: '一五钟重击尾段',
+    params: { team: true },
+    dmg: ({ talent }, dmg) => dmg(talent.a['荒泷逆袈裟终结伤害'], 'a2')
+  
+  }, {
+    title: '一五钟Q后E伤害',
+    params: { team: true },
+    dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+  }
+  ]
+  
+  export const mainAttr = 'atk,cpct,cdmg'
+  export const enemyName = '魔偶/女士/雷神'
+  
+  export const defParams = {
+    team: true
+  }
+  
+  export const buffs = [{
+    title: '一斗被动：荒泷逆袈裟造成的伤害基于防御值提高[a2Plus]',
+    data: {
+      a2Plus: ({ attr, calc }) => calc(attr.def) * 0.35
+    }
+  }, {
+    title: '一斗6命：重击的暴击伤害提高70%',
+    cons: 6,
+    data: {
+      a2Cdmg: 70
+    }
+  }, {
+    title: '一斗大招：怒目鬼王状态提高攻击力[atkPlus]',
+    data: {
+      atkPlus: ({ attr, calc, talent }) => talent.q['攻击力提高'] * calc(attr.def) / 100
+    }
+  }, {
+    check: ({ params }) => params.team === true,
+    title: '6命五郎：增加[defPlus]点防御力与[defPct]%防御力，增加[dmg]%岩伤与[cdmg]%暴击伤害',
+    sort: 0,
+    data: {
+      cdmg: 40,
+      defPct: 25,
+      defPlus: 438,
+      dmg: 15
+    }
+  }, {
+    check: ({ params }) => params.team === true,
+    title: '钟离：降低敌人[kx]%全抗',
+    data: {
+      kx: 20
+    }
+  }
+  ]
+  


### PR DESCRIPTION
编辑：增加了胡桃双水钟离、一五钟岩队、可莉三火的伤害计算。
------
原八重组队温三雷判断条件：

2-5命八重搭配6+5温迪，6命八重搭配0+1温迪，1命以下没有温迪（什么鬼

现在修正为：0-5命八重搭配0+1温迪，6命八重搭配6+5温迪。应该更接近实际状况吧…