### PR TITLE
The API route has been updated.

### DIFF
--- a/config/system/profile_system.js
+++ b/config/system/profile_system.js
@@ -25,11 +25,7 @@ export const enkaApi = {
   url: 'https://enka.network/',
   userAgent: 'Miao-Plugin/3.0',
   listApi: ({ url, uid, diyCfg }) => {
-    let api = `${url}u/${uid}/__data.json`
-    if (diyCfg?.apiKey) {
-      api += '?key=' + diyCfg.apiKey
-    }
-    return api
+    return api `${url}api/uid/${uid}/`
   }
 }
 


### PR DESCRIPTION
I changed the URL to the API. `__data.json` will not work anymore.
There's now also `enka.network/api/uid/${uid}/?info` (test at `https://dev.enka.network/api/uid/600001919/?info`), which will return *only* the player info, but not avatar info. If you need it, you can use it, it's very fast compared to full data request.