### PR TITLE
添加草神，魈，散兵组队伤害

### DIFF
--- a/resources/meta/character/流浪者/calc_auto.js
+++ b/resources/meta/character/流浪者/calc_auto.js
@@ -1,0 +1,152 @@
+export const details = [{
+  title: '开E后首段普攻',
+  params: { pyro: false,cryo:false,team:false,team_ye:false},
+  dmg: ({ talent }, dmg) => dmg(talent.a['一段伤害'], 'a')
+},{
+  title: '开E后重击',
+  params: { pyro: false,cryo:false,team:false,team_ye:false},
+  dmg: ({ talent }, dmg) => dmg(talent.a['重击伤害'], 'a2')
+}, {
+  title: '开E满染火首段普攻',
+  params: { pyro: true,cryo:false,team:false,team_ye:false},
+  dmg: ({ talent }, dmg) => dmg(talent.a['一段伤害'], 'a')
+}, {
+  title: '开E满染火染冰首段普攻',
+  params: { pyro: true,cryo:true,team:false,team_ye:false},
+  dmg: ({ talent }, dmg) => dmg(talent.a['一段伤害'], 'a')
+}, {
+  title: '狂言·式乐五番',
+  params: { pyro: true,cryo:true,team:false,team_ye:false},
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'], 'q')
+}, {
+  check: ({ cons }) => cons >= 6,
+  dmgKey: 'e',
+  title: '散夜珐班E后普攻6轮接Q',
+  params: { pyro: true,cryo:false,team:true,team_ye:true},
+  dmg: ({ talent , cons}, dmg) =>{
+  let a_1Dmg = dmg(talent.a['一段伤害'], 'a')
+  let a_2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a_3Dmg = dmg(talent.a['三段伤害']/2, 'a')
+//   let count = cons * 1 === 6 ? 1 : 0,
+  let a1_2Dmg = dmg(talent.a['一段伤害']*0.4, 'a')
+  let a2_2Dmg = dmg(talent.a['二段伤害']*0.4, 'a')
+  let a3_2Dmg = dmg(talent.a['三段伤害']*0.4/2, 'a')
+  let Q_Dmg = dmg(talent.q['技能伤害'], 'q')
+  return {
+      avg: 6*(a_1Dmg.avg +a_2Dmg.avg +a_3Dmg.avg *2 + a1_2Dmg.avg +a2_2Dmg.avg +a3_2Dmg.avg*2) +Q_Dmg.avg,
+      dmg: 6*(a_1Dmg.dmg +a_2Dmg.dmg +a_3Dmg.dmg *2 + a1_2Dmg.dmg +a2_2Dmg.dmg +a3_2Dmg.dmg*2) +Q_Dmg.dmg
+    }
+  }
+}, {
+  check: ({ cons }) => cons < 6,
+  dmgKey: 'e',
+  title: '散夜珐班E后普攻6轮接Q',
+  params: { pyro: true,cryo:false,team:true,team_ye:true},
+  dmg: ({ talent , cons}, dmg) =>{
+  let a_1Dmg = dmg(talent.a['一段伤害'], 'a')
+  let a_2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a_3Dmg = dmg(talent.a['三段伤害']/2, 'a')
+  let Q_Dmg = dmg(talent.q['技能伤害'], 'q')
+  return {
+      avg: 6*(a_1Dmg.avg +a_2Dmg.avg +a_3Dmg.avg *2 ) +Q_Dmg.avg,
+      dmg: 6*(a_1Dmg.dmg +a_2Dmg.dmg +a_3Dmg.dmg *2 ) +Q_Dmg.dmg
+    }
+  }
+}, {
+  check: ({ cons }) => cons >= 6,
+  dmgKey: 'q',
+  title: '散珐云班E后普攻6轮接Q',
+  params: { pyro: true,cryo:false,team:true,team_ye:false},
+  dmg: ({ talent , cons}, dmg) =>{
+  let a_1Dmg = dmg(talent.a['一段伤害'], 'a')
+  let a_2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a_3Dmg = dmg(talent.a['三段伤害']/2, 'a')
+//   let count = cons * 1 === 6 ? 1 : 0,
+  let a1_2Dmg = dmg(talent.a['一段伤害']*0.4, 'a')
+  let a2_2Dmg = dmg(talent.a['二段伤害']*0.4, 'a')
+  let a3_2Dmg = dmg(talent.a['三段伤害']*0.4/2, 'a')
+  let Q_Dmg = dmg(talent.q['技能伤害'], 'q')
+  return {
+      avg: 6*(a_1Dmg.avg +a_2Dmg.avg +a_3Dmg.avg *2 + a1_2Dmg.avg +a2_2Dmg.avg +a3_2Dmg.avg*2) +Q_Dmg.avg,
+      dmg: 6*(a_1Dmg.dmg +a_2Dmg.dmg +a_3Dmg.dmg *2 + a1_2Dmg.dmg +a2_2Dmg.dmg +a3_2Dmg.dmg*2) +Q_Dmg.dmg
+    }
+  }
+}, {
+  check: ({ cons }) => cons < 6,
+  dmgKey: 'q',
+  title: '散珐云班E后普攻6轮接Q',
+  params: { pyro: true,cryo:false,team:true,team_ye:false},
+  dmg: ({ talent , cons}, dmg) =>{
+  let a_1Dmg = dmg(talent.a['一段伤害'], 'a')
+  let a_2Dmg = dmg(talent.a['二段伤害'], 'a')
+  let a_3Dmg = dmg(talent.a['三段伤害']/2, 'a')
+  let Q_Dmg = dmg(talent.q['技能伤害'], 'q')
+  return {
+      avg: 6*(a_1Dmg.avg +a_2Dmg.avg +a_3Dmg.avg *2 ) +Q_Dmg.avg,
+      dmg: 6*(a_1Dmg.dmg +a_2Dmg.dmg +a_3Dmg.dmg *2 ) +Q_Dmg.dmg
+    }
+  }
+}]
+
+export const defDmgKey = 'e'
+export const mainAttr = 'atk,cpct,cdmg'
+
+
+export const defParams = {
+    pyro: true,cryo:true,team:true,team:true,team_ye:true
+}
+
+
+export const buffs = [{
+  title: '羽画·风姿华歌：开启E后额外提升普通[aMulti]%伤害,重击[a2Multi]%伤害',
+  data: {
+    aMulti: ({ talent }) => talent.e['空居·不生断伤害'] - 100,
+    a2Multi: ({ talent }) => talent.e['空居·刀风界伤害'] - 100
+  }
+}, {
+  title: '天赋拾玉得花：火元素攻击力提升30%,冰元素暴击率提升20%',
+  data: {
+    atkPct: ({ params }) => params.pyro ? 30 : 0,
+    cpct: ({ params }) => params.cryo ? 20 : 0,
+  }
+}, {
+  title: '二番·箙岛月白浪：至多使狂言·式乐五番造成的伤害提升200%',
+  cons: 2,
+  data: {
+    qDmg: 200
+  }
+}, {
+  title: '四番·花月歌浮舟：染色+1，默认冰',
+  cons: 4,
+  data: {
+    cpct: ({ params }) => params.cryo ? 0 : 20
+  }
+}, {check: ({ params }) => params.team === true,
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {check: ({ params }) => params.team === true,
+    title: '满命珐露珊：获得[dmg]%增伤,获得[kx]%减抗,获得[cdmg]%爆伤',
+    data: {
+      dmg: 40,
+      kx: 30,
+      cdmg:40,
+   }
+  }, {check: ({ params }) => params.team === true && params.team_ye === true,
+    title: '夜兰：获得[dmg]%增伤',
+    data: {
+      dmg: 35
+   }
+  }, {check: ({ cons,params }) => cons >= 6 &&params.team === true && params.team_ye === false,
+    title: '云堇：普攻附加伤害2000',
+    data: {
+      aPlus: 1250
+   }
+  }, {check: ({ cons,params }) => cons < 6 &&params.team === true && params.team_ye === false,
+    title: '云堇：普攻附加伤害2000',
+    data: {
+      aPlus: 2000
+   }
+  }]

--- a/resources/meta/character/纳西妲/calc_auto.js
+++ b/resources/meta/character/纳西妲/calc_auto.js
@@ -1,0 +1,106 @@
+export const details = [{
+  title: 'E长按伤害',
+  params: { e: true, q: false ,team : false},
+  dmg: ({ talent }, dmg) => dmg(talent.e['长按伤害'], 'e')
+}, {
+  title: '灭净三业伤害',
+  params: { e2: true, q: false ,team : false},
+  dmg: ({ talent, calc, attr }, { basic }) => {
+    const td = talent.e['灭净三业伤害2']
+    const em = calc(attr.mastery)
+    const atk = calc(attr.atk)
+    return basic(td[0] * atk / 100 + td[1] * em / 100, 'e')
+  }
+}, {
+  title: '开Q灭净三业伤害',
+  params: { e2: true ,team : false},
+  dmg: ({ talent, calc, attr, cons }, { basic }) => {
+    const td = talent.e['灭净三业伤害2']
+    const em = calc(attr.mastery)
+    const atk = calc(attr.atk)
+    return basic(td[0] * atk / 100 + td[1] * em / 100, 'e')
+  }
+}, {
+  title: '灭净三业·蔓激化',
+  params: { e2: true, q: false ,team : false},
+  dmg: ({ talent, calc, attr }, { basic }) => {
+    const td = talent.e['灭净三业伤害2']
+    const em = calc(attr.mastery)
+    const atk = calc(attr.atk)
+    return basic(td[0] * atk / 100 + td[1] * em / 100, 'e', 'spread')
+  }
+}, {
+  title: '开Q灭净三业·蔓激化',
+  params: { e2: true ,team : false},
+  dmg: ({ talent, calc, attr, cons }, { basic }) => {
+    const td = talent.e['灭净三业伤害2']
+    const em = calc(attr.mastery)
+    const atk = calc(attr.atk)
+    return basic(td[0] * atk / 100 + td[1] * em / 100, 'e', 'spread')
+  }
+}, {
+  title: '提八纳皇开Q灭净三业·蔓激化',
+  params: { e2: true ,team : true},
+  dmg: ({ talent, calc, attr, cons }, { basic }) => {
+    const td = talent.e['灭净三业伤害2']
+    const em = calc(attr.mastery)
+    const atk = calc(attr.atk)
+    return basic(td[0] * atk / 100 + td[1] * em / 100, 'e', 'spread')
+  }
+}]
+
+
+export const defParams = {
+    q: true,team:true
+}
+
+export const defDmgIdx = 5
+export const mainAttr = 'atk,mastery,cpct,cdmg'
+
+export const buffs = [{
+  title: '草神1命：火元素队友额外计入1位',
+  cons: 1
+}, {
+  title: '草神2命：激化相关反应降低敌人防御力30%',
+  cons: 2,
+  data: {
+    enemyDef: 30
+  }
+}, {
+  title: '草神4命：E4个敌人提升精通160',
+  cons: 4,
+  data: {
+    mastery: 160
+  }
+}, {
+  check: ({ cons,params }) =>  (cons <=4 && params.team === true),
+  title: '提八皇组队buff：双草教官精1终末皇女[mastery],[atkPct]%攻击力',
+  data: {
+    mastery:320,
+    atkPct:20
+  }
+},{
+  check: ({ cons,params }) =>  (cons >4 && params.team === true),
+  title: '提八皇组队buff：双草教官精5终末皇女4命提纳里[mastery],[atkPct]%攻击力',
+  data: {
+    mastery:540,
+    atkPct:40
+  }
+}, {
+  title: '草神被动：开Q元素精通提升[mastery]',
+  data: {
+    mastery: ({ calc, attr, params }) => (params.q === false ? 0 : 1) * Math.min(250, calc(attr.mastery) * 0.25)
+  }
+}, {
+  title: '草神被动：基于元素精通提升灭净三业伤害[eDmg]%，暴击率[eCpct]%',
+  data: {
+    eDmg: ({ calc, attr, params }) => (params.e ? 0 : 1) * Math.min(80, (calc(attr.mastery) - 200) * 0.1),
+    eCpct: ({ calc, attr, params }) => (params.e ? 0 : 1) * Math.min(24, (calc(attr.mastery) - 200) * 0.03)
+  }
+}, {
+  title: '草神Q：开Q提升灭净三业伤害[eDmg]%',
+  data: {
+    eDmg: ({ cons, talent, params }) => (params.q === false ? 0 : 1) *
+      (cons >= 1 ? talent.q['火2伤害提升'] : talent.q['火1伤害提升'])
+  }
+}]

--- a/resources/meta/character/魈/calc_auto.js
+++ b/resources/meta/character/魈/calc_auto.js
@@ -1,0 +1,63 @@
+export const details = [{
+  title: '风轮两立',
+  params: { team:false},
+  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+}, {
+  title: '开Q满被动E',
+  params: { e: 1, layer: 5 ,team:false},
+  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+}, {
+  title: '靖妖傩舞·首插',
+  params: {
+    layer: 1 , team:false
+  },
+  dmg: ({ talent }, dmg) => dmg(talent.a['低空/高空坠地冲击伤害'][1], 'a3')
+}, {
+  title: '靖妖傩舞·尾插',
+  params: {
+    layer: 5 , team:false
+  },
+  dmg: ({ talent }, dmg) => dmg(talent.a['低空/高空坠地冲击伤害'][1], 'a3')
+}, {
+  title: '魈珐班 开Q满被动E',
+  params: { e: 1, layer: 5 ,team:true},
+  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+}]
+
+export const defDmgIdx = 4
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const defParams = {
+  layer: 0,
+  team:true
+}
+
+export const buffs = [{
+  title: '靖妖傩舞：下落攻击伤害提升[a3Dmg]%',
+  data: {
+    a3Dmg: ({ talent }) => talent.q['普通攻击/重击/下落攻击伤害提升']
+  }
+}, {
+  title: '魈天赋：开Q后每3秒伤害提升5%，满层提高25%',
+  data: {
+    dmg: ({ params }) => params.layer * 5
+  }
+}, {
+  title: '魈被动：3层E使E的伤害提高45%',
+  data: {
+    eDmg: ({ params }) => params.e ? 45 : 0
+  }
+}, {check: ({ params }) => params.team === true,
+    title: '风鹰宗室班：增加[atkPlus]点攻击力与[atkPct]%攻击力',
+    data: {
+      atkPct: 20,
+      atkPlus: 1202.35
+  }
+  }, {check: ({ params }) => params.team === true,
+    title: '满命珐露珊：获得[dmg]%增伤,获得[kx]%减抗,获得[cdmg]%爆伤',
+    data: {
+      dmg: 40,
+      kx: 30,
+      cdmg:40,
+   }
+  }]


### PR DESCRIPTION
三个组队伤害。
草神默认为提八草皇（海八草皇也差不多伤害）
魈为魈珐班
散兵为散珐夜班与散珐云班