### PR TITLE
更新妮露、瑶瑶、多莉评分规则

### DIFF
--- a/resources/meta/character/多莉/artis.js
+++ b/resources/meta/character/多莉/artis.js
@@ -1,0 +1,3 @@
+export default function ({ rule }) {
+  return rule('多莉-治疗', { hp: 100, dmg: 0, phy: 0, heal:100, recharge: 75 })
+}

--- a/resources/meta/character/妮露/artis.js
+++ b/resources/meta/character/妮露/artis.js
@@ -1,0 +1,13 @@
+export default function ({ attr, weapon, artis, rule, def }) {
+  let title = []
+  let mastery = 60
+  if (weapon.name === '圣显之钥') {
+      // 绽放妮露，其余词缀权重不高于41.84，确保小生命命中副词缀最高权重
+      title.push('专武')
+      mastery = 40
+  }
+  if (artis.is('hp', '3,4,5') && attr.hp > 40000&& attr.cpct * 2 + attr.cdmg < 150) {
+    return rule(`妮露-${title.join('')}绽放`, { hp: 100, mastery, recharge: 25 })
+  }
+  return def({ hp: 75, atk: 75, cpct: 100, cdmg: 100, dmg: 100, recharge: 75 })
+}

--- a/resources/meta/character/瑶瑶/artis.js
+++ b/resources/meta/character/瑶瑶/artis.js
@@ -1,0 +1,3 @@
+export default function ({ rule }) {
+    return rule('瑶瑶-治疗', { hp: 100, mastery:40, dmg: 0, phy: 0, heal:100, recharge: 50 })
+  }


### PR DESCRIPTION
通用的攻双暴模板不适用与妮露，瑶瑶，多莉的练度评估，更新三位角色的评分规则