### PR TITLE
增加八重，菲谢尔激化伤害（八重为组队），久岐忍超绽放伤害，与武器圣遗物结算顺序

### DIFF
--- a/resources/meta/artifact/calc.js
+++ b/resources/meta/artifact/calc.js
@@ -355,7 +355,7 @@ const buffs = {
     2: attr('atkPct', 18),
     4: {
       title: '触发提高普攻[aPlus]伤害',
-      sort: 0,
+      sort: 10,
       data: {
         aPlus: ({ attr }) => (attr.atk.base + attr.atk.plus + attr.atk.pct * attr.atk.base / 100) * 0.35
       }
@@ -376,6 +376,7 @@ const buffs = {
     2: attr('mastery', 80),
     4: {
       title: '队伍存在其他3个不同元素类型角色时，精通提高150',
+      sort: 0,
       data: {
         mastery: 150
       }

--- a/resources/meta/character/久岐忍/calc.js
+++ b/resources/meta/character/久岐忍/calc.js
@@ -1,4 +1,8 @@
-export const details = [{
+export const details = [, {
+  title: '超绽放伤害',
+  dmg: ({calc, attr}, { reaction }) => {
+      return reaction('hyperBloom')}
+},{
   title: 'E释放伤害',
   dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
 }, {

--- a/resources/meta/character/八重神子/calc_auto.js
+++ b/resources/meta/character/八重神子/calc_auto.js
@@ -2,49 +2,68 @@ export const details = [{
   check: ({ cons }) => cons < 2,
   dmgKey: 'e',
   title: '叄阶杀生樱伤害',
-  params: { team: false },
+  params: { team: false ,team2: false},
   dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·叁阶'], 'e')
 }, {
   check: ({ cons }) => cons >= 2,
   dmgKey: 'e',
   title: '肆阶杀生樱伤害',
-  params: { team: false },
+  params: { team: false ,team2: false},
   dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'], 'e')
-}, {
+},{
   check: ({ cons }) => cons < 2,
   dmgKey: 'e_t',
-  params: { team: true },
+  params: { team: true ,team2: false},
   title: '温三雷叄阶杀生樱伤害',
   dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·叁阶'], 'e')
 }, {
   check: ({ cons }) => cons >= 2,
   dmgKey: 'e_t',
-  params: { team: true },
+  params: { team: true ,team2: false},
   title: '温三雷肆阶杀生樱伤害',
   dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'], 'e')
-}, {
+},  {
   title: 'Q天狐霆雷伤害',
-  params: { team: false },
+  params: { team: false ,team2: false},
   dmg: ({ talent }, dmg) => dmg(talent.q['天狐霆雷伤害'], 'q')
 }, {
   title: '温三雷四段Q总伤害',
-  params: { team: true },
+  params: { team: true ,team2: false},
   dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'] + talent.q['天狐霆雷伤害'] * 3, 'q')
+},{
+  check: ({ cons }) => cons < 2,
+  dmgKey: 'e_j',
+  params: { team: false,team2: true },
+  title: '提八纳万叄阶杀生樱激化伤害',
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·叁阶'], 'e', '超激化')
+}, {
+  check: ({ cons }) => cons >= 2,
+  dmgKey: 'e_j',
+  params: { team: false,team2: true },
+  title: '提八纳万肆阶杀生樱激化伤害',
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'], 'e', '超激化')
+}, {
+  title: '提八纳万四段Q总伤害',
+  params: { team: false,team2: true },
+  dmg: ({ talent }, dmg) => {
+    let q1j = dmg(talent.q['技能伤害'], 'q', '超激化')
+    let q2j = dmg(talent.q['天狐霆雷伤害'], 'q', '超激化')
+    return {
+      dmg: q1j.dmg + q2j.dmg * 3,
+      avg: q1j.avg + q2j.avg * 3
+    }
+  }
 }]
 
 export const mainAttr = 'atk,cpct,cdmg,mastery'
-export const defDmgKey = 'e'
+export const defDmgKey = 'e_j'
 
 export const defParams = {
-  team: true
+    team:true,team2:true
 }
 
+
 export const buffs = [{
-  title: '被动天赋：基于元素精通提高杀生樱伤害[eDmg]%',
-  data: {
-    eDmg: ({ attr, calc }) => calc(attr.mastery) * 0.15
-  }
-}, {
   check: ({ cons }) => cons >= 4,
   title: '4命效果：杀生樱命中敌人后提高雷伤[dmg]%',
   data: {
@@ -56,34 +75,82 @@ export const buffs = [{
   data: {
     eDef: 60
   }
-}, {
-  check: ({ cons, params }) => ((cons == 6) && params.team === true),
-  title: '精5终末6命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+}, {check: ({ cons,params }) => (cons >= 6 && params.team === true),
+    title: '精5终末6命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      atkPct:40,
+      kx:60,
+      mastery:200
+   }
+  }, {check: ({ cons,params }) =>  (cons < 6 && cons >1 && params.team === true),
+    title: '精1终末0命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      atkPct:20,
+      kx:40,
+      mastery:100
+   }
+  }, {check: ({ params }) => params.team === true,
+    title: '天空宗室九条：增加[atkPlus]点攻击力,[atkPct]%攻击与[cdmg]%爆伤',
+    data: {
+      atkPlus: 794.2,
+      atkPct:20,
+      cdmg:60
+   }
+  }, {check: ({ cons,params }) =>  (cons >= 2&&cons < 6&& params.team2 === true),
+    title: '精1千夜纳西妲提纳里：增加精通[mastery]（包括双草）,减防[enemyDef]%',
+    data: {
+      mastery: 140,
+      enemyDef: 30,
+   }
+  }, {check: ({ cons,params }) =>  (cons >= 6&& params.team2 === true),
+    title: '精5千夜纳西妲提纳里：增加精通[mastery]（包括双草）,减防[enemyDef]（折合效果）%',
+    data: {
+      mastery: 268,
+      enemyDef: 12,
+   }
+  }, {check: ({ cons,params }) =>  (cons < 2&& params.team2 === true),
+    title: '精1千夜草套纳西妲提纳里：增加精通[mastery]（包括双草)',
+    data: {
+      mastery: 140
+   }
+  }, {check: ({ cons,params }) => cons <= 1 && params.team2 === true,
+    title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 40,
+      atkPct:20,
+      kx:40,
+   }
+  }, {check: ({ cons,params }) => ((cons < 6 && cons >1) && params.team2 === true),
+    title: '精1苍古2命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:16,
+      a2Dmg:16,
+      a3Dmg:16,
+      dmg: 48,
+      atkPct:20,
+      kx:40,
+   }
+  }, {check: ({ cons,params }) =>  (cons >= 6 && params.team2 === true),
+    title: '精5苍古6命万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
+    data: {
+      aDmg:32,
+      a2Dmg:32,
+      a3Dmg:32,
+      dmg: 48,
+      atkPct:40,
+      kx:40,
+   }
+  },{
+  title: '被动天赋：基于元素精通提高杀生樱伤害[eDmg]%',
   data: {
-    atkPct: 40,
-    kx: 60,
-    mastery: 200
+    eDmg: ({ attr, calc }) => calc(attr.mastery) * 0.15
   }
-}, {
-  check: ({ cons, params }) => (cons <= 5 && params.team === true),
-  title: '精1终末0命温迪：增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
-  data: {
-    atkPct: 20,
-    kx: 40,
-    mastery: 100
-  }
-}, {
-  check: ({ params }) => params.team === true,
-  title: '天空宗室九条：增加[atkPlus]点攻击力,[atkPct]%攻击与[cdmg]%爆伤',
-  data: {
-    atkPlus: 794.2,
-    atkPct: 20,
-    cdmg: 60
-  }
-}, {
-  check: ({ params }) => params.team === true,
-  title: '恶曜开眼：开E元素爆发伤害提升[qDmg]%',
-  data: {
-    qDmg: 27
-  }
-}]
+}, {check: ({ params }) => params.team === true,
+    title: '恶曜开眼：开E元素爆发伤害提升[qDmg]%',
+    data: {
+      qDmg: 27
+    }
+  }]

--- a/resources/meta/character/夜兰/calc_auto.js
+++ b/resources/meta/character/夜兰/calc_auto.js
@@ -57,9 +57,9 @@ export const defParams = {
 
 
 export const buffs = [{
-  title: '夜兰被动：有4个不同元素类型角色时，夜兰生命值上限提高30%',
+  title: '夜兰被动：有3个不同元素类型角色时，夜兰生命值上限提高18%',
   data: {
-    hpPct: 30
+    hpPct: 18
   }
 }, {
   title: '夜兰4命：E络命丝爆发提高生命值，满Buff下提高40%',

--- a/resources/meta/character/神里绫华/artis.js
+++ b/resources/meta/character/神里绫华/artis.js
@@ -2,5 +2,5 @@ export default function ({ attr, rule, def }) {
   if (attr.mastery > 120) {
     return rule('神里-精通', { atk: 75, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, recharge: 30 })
   }
-  return def({ atk: 75, cpct: 100, cdmg: 100, dmg: 100, phy: 100, recharge: 30 })
+  return def({ atk: 75, cpct: 100, cdmg: 100, dmg: 100, phy: 0, recharge: 30 })
 }

--- a/resources/meta/character/菲谢尔/calc.js
+++ b/resources/meta/character/菲谢尔/calc.js
@@ -1,4 +1,7 @@
 export const details = [{
+  title: '奥兹攻击激化伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['奥兹攻击伤害'], 'e', '超激化')
+}, {
   title: '奥兹攻击伤害',
   dmg: ({ talent }, dmg) => dmg(talent.e['奥兹攻击伤害'], 'e')
 }, {
@@ -10,7 +13,7 @@ export const details = [{
   dmg: ({ talent, cons }, dmg) => dmg(talent.q['落雷伤害'], 'q')
 }]
 
-export const mainAttr = 'atk,cpct,cdmg'
+export const mainAttr = 'atk,cpct,cdmg,mastery'
 
 export const buffs = [{
   title: '皇女2命：施放夜巡影翼时，能额外造成200%攻击力的伤害',

--- a/resources/meta/weapon/sword/calc.js
+++ b/resources/meta/weapon/sword/calc.js
@@ -150,6 +150,7 @@ export default function (step, staticStep) {
     }],
     裁叶萃光: [staticStep('cpct', 4), {
       title: '普攻与元素战技造成的伤害值提高[aPlus]',
+      sort: 5,
       data: {
         aPlus: ({ attr, calc, refine }) => calc(attr.mastery) * step(120)[refine] / 100,
         ePlus: ({ attr, calc, refine }) => calc(attr.mastery) * step(120)[refine] / 100


### PR DESCRIPTION
结算顺序更改：
海哥提纳里专武尽量靠后结算，保证吃到更多的来自攻击力的buff。
饰金最前计算，保证海哥天赋吃得到对应加成。
余响最后计算，保证吃到更多的来自攻击力的buff。
功能增加：
八重菲谢尔激化伤害增加
久岐忍添加超绽放伤害，微测试花园套（我没有）。
bug修复：
修复了神里评分的物伤杯bug，夜兰组队状态应为3色天赋。