### PR TITLE
修复碧落之珑计算bug

### DIFF
--- a/resources/meta/weapon/catalyst/calc.js
+++ b/resources/meta/weapon/catalyst/calc.js
@@ -151,7 +151,7 @@ export default function (step, staticStep) {
     碧落之珑: {
       title: '释放元素爆发后基于生命值提高元素伤害[dmg]%',
       data: {
-        dmg: (attr, calc, refine) => Math.min(Math.floor(calc(attr.hp) / 1000) * step(0.3, 0.2), step(12, 8))
+        dmg: ({attr, calc, refine}) => Math.min(Math.floor(calc(attr.hp) / 1000) * step(0.3, 0.2)[refine], step(12, 8)[refine])
       }
     }
   }


### PR DESCRIPTION
具体问题是：https://github.com/yoimiya-kokomi/miao-plugin/issues/561

修复以后发现原函数忘记给精炼等级了，会导致计算Nan，所以顺便加上了。个人测试没问题了。