### PR TITLE
解决QQ频道调用时无法输出排名的问题

### DIFF
--- a/models/ProfileRank.js
+++ b/models/ProfileRank.js
@@ -35,7 +35,7 @@ export default class ProfileRank {
     let keys = await redis.keys(`miao:rank:${groupId}:${type}:*`)
     let ret = []
     for (let key of keys) {
-      let keyRet = /^miao:rank:\d+:(?:mark|dmg|crit|valid):(\d{8})$/.exec(key)
+      let keyRet = /^miao:rank:[\w-]+:(?:mark|dmg|crit|valid):(\d{8})$/.exec(key)
       if (keyRet && keyRet[1]) {
         let charId = keyRet[1]
         let uid = await ProfileRank.getGroupMaxUid(groupId, charId, type)


### PR DESCRIPTION
QQ频道的groupId格式类似qg_113458249547xxxxxxxx-9719xxx，
x为数字，修改正则表达式适配该格式