### PR TITLE
fix 修复 #更新排名 命令无法获取uid绑定信息

### DIFF
--- a/models/ProfileRank.js
+++ b/models/ProfileRank.js
@@ -199,9 +199,7 @@ export default class ProfileRank {
     let uidMap = {}
     let qqMap = {}
     let add = (qq, uid, type) => {
-      if (!uidMap || type === 'ck') {
-        uidMap[uid] = { uid, qq, type: type === 'ck' ? 'ck' : 'bind' }
-      }
+      uidMap[uid] = { uid, qq, type: type === 'ck' ? 'ck' : 'bind' }
       qqMap[qq] = true
     }
 


### PR DESCRIPTION
#更新排名 时发现无法获取到群员uid
修改后测试已正常