### PR TITLE
fix: 补充artis-mark.js中遗漏的角色

### DIFF
--- a/resources/meta/artifact/artis-mark.js
+++ b/resources/meta/artifact/artis-mark.js
@@ -3,6 +3,9 @@
  * 如character/${name}/artis.js下有角色自定义规则优先使用自定义
  */
 export const usefulAttr = {
+  芭芭拉: { hp: 100, atk: 50, cpct: 50, cdmg: 50, dmg: 80, recharge: 55, heal: 100 },
+  甘雨: { atk: 75, cpct: 100, cdmg: 100, mastery: 75, dmg: 100 },
+  雷电将军: { atk: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 75, recharge: 90 },
   神里绫人: { hp: 50, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 0 },
   八重神子: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   申鹤: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },


### PR DESCRIPTION
我的一个项目引用了这个文件，一些角色数据的缺失导致我的项目报错了……希望补上（这些value均来自对应角色的artis.js）