### PR TITLE
修改香菱伤害计算

### DIFF
--- a/resources/meta-gs/character/香菱/calc_auto.js
+++ b/resources/meta-gs/character/香菱/calc_auto.js
@@ -8,10 +8,19 @@ export const details = [{
   dmg: ({ talent }, dmg) => dmg(talent.e['喷火伤害'], 'e', 'vaporize')
 }, {
   title: ' 旋火轮单次伤害',
+  let i = 1,
   params: { team: false },
   dmg: ({ talent }, dmg) => dmg(talent.q['旋火轮伤害'], 'q')
 }, {
+  title: '雷国旋火轮单次蒸发',
+  let i = 1,
+  let x = 2,
+  params: { team: true },
+  dmg: ({ talent }, dmg) => dmg(talent.q['旋火轮伤害'], 'q', 'vaporize')
+},{
   title: '万达旋火轮单次蒸发',
+  let i = 1,
+  let x = 1,
   params: { team: true },
   dmg: ({ talent }, dmg) => dmg(talent.q['旋火轮伤害'], 'q', 'vaporize')
 }]
@@ -30,10 +39,11 @@ export const buffs = [{
     kx: 15
   }
 }, {
+  check: i !== 1,
   title: '香菱6命：旋火轮持续期间获得15%火伤加成',
   cons: 6,
   data: {
-    qDmg: 15
+    dmg: 15
   }
 }, {
   check: ({ params }) => params.team === true,
@@ -48,7 +58,13 @@ export const buffs = [{
     atkPct: 20
   }
 }, {
-  check: ({ cons, params }) => cons <= 1 && params.team === true,
+  check: x == 2,
+  title: '雷电将军增伤：获得[qDmg]%元素爆发增伤',
+  data: {
+    qDmg: 24
+  }
+},{
+  check: ({ cons, params }) => cons <= 1 && params.team === true && x == 1,
   title: '精1苍古0命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%',
   data: {
     aDmg: 16,
@@ -59,7 +75,7 @@ export const buffs = [{
     kx: 40
   }
 }, {
-  check: ({ cons, params }) => ((cons < 6 && cons > 1) && params.team === true),
+  check: ({ cons, params }) => ((cons < 6 && cons > 1) && params.team === true && x == 1),
   title: '精1苍古2命万叶：获得[dmg]%增伤(苍古普攻16增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
   data: {
     aDmg: 16,
@@ -71,7 +87,7 @@ export const buffs = [{
     mastery: 200
   }
 }, {
-  check: ({ cons, params }) => (cons >= 6 && params.team === true),
+  check: ({ cons, params }) => (cons >= 6 && params.team === true && x == 1),
   title: '精5苍古6命万叶：获得[dmg]%增伤(苍古普攻32增伤)，增加[atkPct]%攻击,减抗[kx]%,精通[mastery]',
   data: {
     aDmg: 32,


### PR DESCRIPTION
实测香菱Q无法吃到6命的火伤加成，这里修改了一下只让E吃6命。新增“雷国旋火轮单次蒸发”伤害。