### PR TITLE
更新那维莱特的圣遗物评分，将充能权重从75降低至55。

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -74,7 +74,7 @@ export const usefulAttr = {
   林尼: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   琳妮特: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   菲米尼: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 100, recharge: 55, heal: 0 },
-  那维莱特: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 75, heal: 0 },
+  那维莱特: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   莱欧斯利: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   芙宁娜: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 45, dmg: 100, phy: 0, recharge: 75, heal: 100 },
   夏洛蒂: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 75, heal: 100 },


### PR DESCRIPTION
那维莱特首次UP时候，芙宁娜还没实装。
那维莱特带行秋or夜兰还是太抽象了，根本触发不了这俩协同攻击。
所以那维莱特自己要堆点充能，圣遗物评分充能权重给到了 75。

芙宁娜实装后，那维莱特队友里，芙宁娜占比非常高。
故调整那维莱特，将充能权重从75降低至55（参考魈圣遗物评分，充能权重同样为55）。