### PR TITLE
更新神里绫华、克洛琳德、托马的圣遗物评分权重

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -16,7 +16,7 @@ export const usefulAttr = {
   枫原万叶: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 100, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   行秋: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 75, heal: 0 },
   钟离: { hp: 80, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 50, recharge: 55, heal: 0 },
-  神里绫华: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 0 },
+  神里绫华: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 0 },
   香菱: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   胡桃: { hp: 80, atk: 50, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 0, heal: 0 },
   温迪: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
@@ -36,7 +36,7 @@ export const usefulAttr = {
   凝光: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 0 },
   北斗: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   刻晴: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 100, recharge: 0, heal: 0 },
-  托马: { hp: 90, atk: 55, def: 0, cpct: 90, cdmg: 90, mastery: 75, dmg: 90, phy: 0, recharge: 55, heal: 0 },
+  托马: { hp: 100, atk: 50, def: 0, cpct: 50, cdmg: 50, mastery: 75, dmg: 80, phy: 0, recharge: 75, heal: 0 },
   迪卢克: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 0, heal: 0 },
   诺艾尔: { hp: 0, atk: 50, def: 90, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 70, heal: 0 },
   旅行者: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
@@ -84,6 +84,6 @@ export const usefulAttr = {
   嘉明: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   千织: { hp: 0, atk: 50, def: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   阿蕾奇诺: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
-  克洛琳德: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
+  克洛琳德: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   希格雯: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 100 }
 }


### PR DESCRIPTION
将神里绫华和克洛琳德的攻击权重，从 75 提升至 85 。
克洛琳德的精通权重，从 75 降至 30 。
托马的生命权重提高到 100，攻击、双暴三项权重降至 50，充能权重提高到 75。

首先，神里绫华单人Q伤害，攻击头的期望以微弱优势高于暴伤头。
在队伍里有申鹤（1命）的情况下，神里Q的总伤，经本人面板测试，暴伤头只比攻击头高出仅仅 1% 左右。
如果是2命神里，则攻击头和暴伤头的Q总伤期望，几乎持平。
**当然对于不同面板来说，数据肯定会存在差异。
但至少能说明一个问题——将神里绫华的攻击权重，和其它主C角色设置成同为 75，这点是不合理的。**
为了和其他角色作为区分，故将神里绫华的攻击权重，从 75 提升至 85。

关于克洛琳德激化，0命克洛琳德自身一轮总攻击倍率能达到四五千（包括元素爆发和天赋），她的攻击词条的收益接近绫华（高命克洛琳德更甚）。
克洛琳德自身没有精通转模，**圣遗物精通副词条带来的激化伤害加成对于总伤的收益，远远远远低于攻击词条**
若将攻击和精通权重同设置成 75，将会让其它玩家误以为克洛琳德可以带精通沙，显然这是不对的。
