### PR TITLE
更新艾尔海森、赛索斯、克洛琳德评分权重

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -65,7 +65,7 @@ export const usefulAttr = {
   流浪者: { hp: 0, atk: 80, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 35, heal: 0 },
   珐露珊: { hp: 0, atk: 75, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 100, phy: 0, recharge: 100, heal: 0 },
   瑶瑶: { hp: 100, atk: 75, def: 0, cpct: 30, cdmg: 30, mastery: 75, dmg: 100, phy: 0, recharge: 75, heal: 100 },
-  艾尔海森: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 100, dmg: 100, phy: 0, recharge: 35, heal: 0 },
+  艾尔海森: { hp: 0, atk: 55, def: 0, cpct: 100, cdmg: 100, mastery: 100, dmg: 100, phy: 0, recharge: 35, heal: 0 },
   迪希雅: { hp: 75, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 100, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   米卡: { hp: 75, atk: 55, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 75, phy: 75, recharge: 55, heal: 100 },
   白术: { hp: 100, atk: 0, def: 0, cpct: 30, cdmg: 30, mastery: 75, dmg: 100, phy: 0, recharge: 75, heal: 100 },
@@ -84,7 +84,7 @@ export const usefulAttr = {
   嘉明: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   千织: { hp: 0, atk: 50, def: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   阿蕾奇诺: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
-  赛索斯: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
-  克洛琳德: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 55, heal: 0 },
+  赛索斯: { hp: 0, atk: 30, def: 0, cpct: 100, cdmg: 100, mastery: 100, dmg: 100, phy: 0, recharge: 55, heal: 0 },
+  克洛琳德: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   希格雯: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 100 }
 }


### PR DESCRIPTION
精1专武克洛琳德，雷伤杯+攻击头 > 雷伤杯+暴伤头 ≈ 攻击杯+暴伤头。如果是精5专武，显然是攻击杯毕业。 龙王毕业面板是水伤杯+生命头，龙王的生命权重都能给到 100 。
克洛琳德，精1专武攻击杯打平雷伤杯，精5专武攻击杯毕业。真的没有理由不给 100 权重。

艾尔海森无论是黎明神剑、裁叶萃光，还是哪怕 674 白值的雾切，精通沙伤害都是吊打攻击沙的。把艾尔海森攻击权重甚至成 75 并不合理，这里把艾尔海森攻击权重，调整成和纳西妲一样，都是 55 。

赛索斯的精通倍率更夸张，天赋和普攻自带，让他拥有全游最高的 942 精通倍率，相比之下攻击倍率仅仅只有 252 。精通倍率占比之大，远远高于艾尔海森和纳西妲。故把赛索斯攻击权重降低至 30 ，精通权重提高至 100 。