### PR TITLE
fix. 修复uid与qq号对应关系不刷新的问题

### DIFF
--- a/apps/profile/ProfileList.js
+++ b/apps/profile/ProfileList.js
@@ -59,8 +59,8 @@ const ProfileList = {
     if (e.runtime && e.runtime?.user) {
       let uids = []
       let user = e.runtime.user
-      if (typeof user.getCkUidList === 'function') {
-        uids = user.getCkUidList(e.game).map(i => i.uid) || []
+      if (typeof user.getUidList === 'function') {
+        uids = user.getUidList(e.game).map(i => i.uid) || []
       } else {
         uids = user.ckUids || []
       }


### PR DESCRIPTION
此前遇到了一个bug：当uid被其他人抢先绑定之后，即使对方取消绑定，无论如何操作，排行榜等处显示的头像仍然会显示对方的头像。

经过分析，该bug问题在于redis数据库`miao:rank:uid-info:{uid}`内存储的qq号不刷新，而更新该处数据库的方法为`setUidInfo`。该方法只在两处被调用，其一：

![4d398499b4f666e768e7c1e2df3ea315](https://github.com/yoimiya-kokomi/miao-plugin/assets/91231470/30c3d629-736b-46ac-b59b-ec0aece80cd4)

并不会实际更新数据库，其二来自本pr修改的`render`函数，其首先定义了`isSelfUid`：

![67adf1278392c25cd1044afd40ebfaf7](https://github.com/yoimiya-kokomi/miao-plugin/assets/91231470/2faeb907-6641-4fc8-9fd6-8b2460774f91)

然后传入`setUidInfo`：

![image](https://github.com/yoimiya-kokomi/miao-plugin/assets/91231470/e2c8a71e-74d4-4669-abdc-21d58782e608)

内部更新qq号逻辑如下：

![b8727e98a5a195e501855d8f43c005b4](https://github.com/yoimiya-kokomi/miao-plugin/assets/91231470/4095563d-c2f1-4701-8aaf-d176b45e62d5)

因此，qq号当前仅当当前uid在`getCkUidList`返回的uid列表中时会被更新。虽然`getCkUidList`函数名已经暗示了其用途，但鉴于是第一次接触本项目代码，确认了一下其逻辑：

![1a4ebb6d97e243ddae450c30c00ec91a](https://github.com/yoimiya-kokomi/miao-plugin/assets/91231470/7a31abfc-8f79-44c7-8dc2-ac29ddffbc96)

![be9abdc7b8e78a1188bd399555899751](https://github.com/yoimiya-kokomi/miao-plugin/assets/91231470/80d4e34c-e558-4317-8e3d-f9cf92b01968)

![9af49bb7a9bb5119fdbfd987f94d9d54](https://github.com/yoimiya-kokomi/miao-plugin/assets/91231470/b5971692-1216-4cd6-a60b-ecc3a389471e)

因此显然，`getCkUidList`只会返回绑定了cookie的uid。

综上，bug的原因在于，只要没有绑定过cookie，只要被人绑定过的uid，其uid-qq对应关系就不再会发生改变，故做出此修改及pr。

此外，本修改不会影响系统健壮性与安全性，毕竟初始的uid-qq对应关系本就是无权鉴的，且本修改涉及的变量均只影响`setUidInfo`函数的`uidType`参数，该参数只涉及对应qq号的更新逻辑。