### PR TITLE
修复万叶默认通用评分标准被自定义通用标准覆盖导致默认标准修改后未生效的问题

### DIFF
--- a/apps/character/AvatarWife.js
+++ b/apps/character/AvatarWife.js
@@ -32,7 +32,7 @@ const relationMap = {
 }
 
 const relation = lodash.flatMap(relationMap, (d) => d.keyword)
-const wifeReg = `^#?\\s*(${relation.join('|')})\\s*(设置|选择|指定|列表|查询|列表|是|是谁|照片|相片|图片|写真|图像)?\\s*([^\\d]*)\\s*(\\d*)$`
+const wifeReg = `^#?\\s*(${relation.join('|')})\\s*(设置|选择|指定|添加|列表|查询|列表|是|是谁|照片|相片|图片|写真|图像)?\\s*([^\\d]*)\\s*(\\d*)$`
 
 async function getAvatarList (player, type) {
   await player.refreshMysDetail()
@@ -78,7 +78,7 @@ const Wife = {
     let action = msgRet[2] || '卡片'
     let actionParam = msgRet[3] || ''
 
-    if (!'设置,选择,挑选,指定'.split(',').includes(action) && actionParam) {
+    if (!'设置,选择,挑选,指定,添加'.split(',').includes(action) && actionParam) {
       return false
     }
 
@@ -136,9 +136,14 @@ const Wife = {
       case '选择':
       case '挑选':
       case '指定':
+      case '添加':
         if (!isSelf) {
           e.reply('只能指定自己的哦~')
           return true
+        }
+        let existingWife = []
+        if (action === '添加') {
+          existingWife = await selfUser.getCfg(`wife.${targetCfg.key}`, [])
         }
         // 选择老婆
         actionParam = actionParam.replace(/(，|、|;|；)/g, ',')
@@ -152,6 +157,7 @@ const Wife = {
               return char.name
             }
           })
+          wifeList = wifeList.concat(existingWife)
           wifeList = lodash.filter(lodash.uniq(wifeList), (d) => !!d)
           addRet = wifeList
           if (addRet.length === 0) {

--- a/models/MysApi.js
+++ b/models/MysApi.js
@@ -34,6 +34,9 @@ export default class MysApi {
     return new User({ id: this.e.user_id, uid: this.uid })
   }
 
+  /**
+   * @returns {Promise<MysApi>} 
+   */
   static async init (e, auth = 'all') {
     if (!e.runtime) {
       Version.runtime()

--- a/resources/meta-gs/character/枫原万叶/artis.js
+++ b/resources/meta-gs/character/枫原万叶/artis.js
@@ -1,4 +1,4 @@
-import { usefulAttr } from "../../artifact/artis-mark"
+import { usefulAttr } from "../../artifact/artis-mark.js"
 
 export default function ({ cons, rule, def }) {
   if (cons === 6) {

--- a/resources/meta-gs/character/枫原万叶/artis.js
+++ b/resources/meta-gs/character/枫原万叶/artis.js
@@ -1,6 +1,8 @@
+import { usefulAttr } from "../../artifact/artis-mark"
+
 export default function ({ cons, rule, def }) {
-    if (cons === 6) {
-      return rule('万叶-满命', { atk: 75, cpct: 100, cdmg: 100, mastery: 100, dmg: 100, recharge: 55 })
-    }
-    return def({ hp: 0, atk: 75, def: 0, cpct: 50, cdmg: 50, mastery: 100, dmg: 100, phy: 0, recharge: 55, heal: 0 })
+  if (cons === 6) {
+    return rule('万叶-满命', { atk: 75, cpct: 100, cdmg: 100, mastery: 100, dmg: 100, recharge: 55 })
   }
+  return def(usefulAttr['枫原万叶'])
+}


### PR DESCRIPTION
* fix issue #761
* feature: 添加老婆 <details> 可以在已设置了老婆的基础上再进行添加，此前只能重新打一堆名字，~~老婆太多就有点麻烦了~~ </details> 