### PR TITLE
对妮露、闲云满命条件下的评分权重设定部分，进行代码优化。新增芙宁娜在满命条件下的评分规则。

### DIFF
--- a/resources/meta-gs/character/妮露/artis.js
+++ b/resources/meta-gs/character/妮露/artis.js
@@ -2,5 +2,5 @@ export default function ({ cons, rule, def }) {
     if (cons === 6) {
       return rule('妮露-满命', { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 80, dmg: 100, phy: 0, recharge: 30, heal: 0 })
     }
-    return def({ hp: 100, atk: 0, def: 0, cpct: 30, cdmg: 30, mastery: 80, dmg: 100, phy: 0, recharge: 30, heal: 0 })
+    return def(usefulAttr['妮露'])
   }

--- a/resources/meta-gs/character/芙宁娜/artis.js
+++ b/resources/meta-gs/character/芙宁娜/artis.js
@@ -1,0 +1,6 @@
+export default function ({ cons, rule, def }) {
+    if (cons === 6) {
+      return rule('芙宁娜-满命', { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 45, dmg: 100, phy: 0, recharge: 75, heal: 95 })
+    }
+    return def(usefulAttr['芙宁娜'])
+  }

--- a/resources/meta-gs/character/闲云/artis.js
+++ b/resources/meta-gs/character/闲云/artis.js
@@ -2,5 +2,5 @@ export default function ({ cons, rule, def }) {
     if (cons === 6) {
       return rule('闲云-满命', { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 35, heal: 95 })
     }
-    return def({ hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 75, heal: 95 })
+    return def(usefulAttr['闲云'])
   }


### PR DESCRIPTION
新增芙宁娜在满命条件下的圣遗物评分权重规则
与0命相比，精通从0 提升至 45.