### PR TITLE
调整玛拉妮和椒丘的圣遗物评分权重

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -89,5 +89,5 @@ export const usefulAttr = {
   希格雯: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 100 },
   艾梅莉埃: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   卡齐娜: { hp: 0, atk: 0, def: 100, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
-  玛拉妮: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 }
+  玛拉妮: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 85, dmg: 100, phy: 0, recharge: 55, heal: 0 }
 }

--- a/resources/meta-sr/character/椒丘/artis.js
+++ b/resources/meta-sr/character/椒丘/artis.js
@@ -1,0 +1,8 @@
+import { usefulAttr } from "../../artifact/artis-mark.js"
+
+export default function ({ cons, rule, def }) {
+  if (cons === 6) {
+    return rule('椒丘-满命', { hp: 75, atk: 75, def: 75, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 100, effDef: 50, dmg: 0 })
+  }
+  return def(usefulAttr['椒丘'])
+}


### PR DESCRIPTION
①调整玛拉妮的圣遗物评分权重
此前低估了玛拉妮的精通价值。
玛拉妮黑曜秘典套 + 专武，且副词条精通值累计小于 50（估值）的情况下，精通杯的单人期望伤害甚至大于水伤杯。
故将玛拉妮的精通权重，从 75 提高到 85.

②增加椒丘在满命情况下的评分权重
与0命相比，双暴权重从0 提升到 100，攻击权重从 50 提升至 75.