### PR TITLE
添加基尼奇，并变更卡齐娜、椒丘（满命）的圣遗物评分权重 

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -88,6 +88,7 @@ export const usefulAttr = {
   克洛琳德: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 35, heal: 0 },
   希格雯: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 30, heal: 100 },
   艾梅莉埃: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 55, heal: 0 },
-  卡齐娜: { hp: 0, atk: 0, def: 100, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
-  玛拉妮: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 85, dmg: 100, phy: 0, recharge: 55, heal: 0 }
+  卡齐娜: { hp: 0, atk: 0, def: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
+  玛拉妮: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 85, dmg: 100, phy: 0, recharge: 55, heal: 0 },
+  基尼奇: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 }
 }

--- a/resources/meta-sr/character/椒丘/artis.js
+++ b/resources/meta-sr/character/椒丘/artis.js
@@ -2,7 +2,7 @@ import { usefulAttr } from "../../artifact/artis-mark.js"
 
 export default function ({ cons, rule, def }) {
   if (cons === 6) {
-    return rule('椒丘-满命', { hp: 75, atk: 75, def: 75, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 100, effDef: 50, dmg: 0 })
+    return rule('椒丘-满命', { hp: 75, atk: 75, def: 75, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 100, effDef: 50, dmg: 100 })
   }
   return def(usefulAttr['椒丘'])
 }


### PR DESCRIPTION
变更椒丘满命条件下的圣遗物评分权重
将元素伤害，从 0 提升至 100（之前遗漏）。

将卡齐娜的防御力权重，从 100 降至 75.
理由：卡齐娜纯防御倍率，天赋里并没有防御力转攻击力等额外转模。之前定义 100 过高。

添加基尼奇的评分权重。
需要特别说明的是，基尼奇的专武，白值非常高，圣遗物攻击副词条的收益比其他角色高，暂定 85 。