### PR TITLE
Fix: 幻想真境剧诗查询必须使用自身ck

### DIFF
--- a/apps/stat/RoleCombatSummary.js
+++ b/apps/stat/RoleCombatSummary.js
@@ -7,7 +7,8 @@ export async function RoleCombatSummary (e) {
   if (!Cfg.get('roleCombat', false) && !isMatch) {
     return false
   }
-  let mys = await MysApi.init(e, 'all')
+  // 需要自身 ck 查询
+  let mys = await MysApi.init(e, 'cookie')
   if (!mys || !mys.uid) {
     if (isMatch) {
       e.reply(`请绑定ck后再使用${e.original_msg || e.msg}`)


### PR DESCRIPTION
之前查询是用 `auth=all`，所以会出现 ck 和 uid 对不上的报错，即 10104

应采取 `auth=cookie`