### PR TITLE
敌人默认等级调整，部分角色圣遗物评分权重调整

### DIFF
--- a/apps/profile/ProfileDetail.js
+++ b/apps/profile/ProfileDetail.js
@@ -178,7 +178,7 @@ let ProfileDetail = {
       wCfg.weapons = await ProfileWeapon.calc(profile)
     }
 
-    let enemyLv = isGs ? (await selfUser.getCfg('char.enemyLv', 91)) : 80
+    let enemyLv = isGs ? (await selfUser.getCfg('char.enemyLv', 103)) : 80
     let dmgCalc = await ProfileDetail.getProfileDmgCalc({ profile, enemyLv, mode, params })
 
     let rank = false

--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -79,8 +79,8 @@ export const usefulAttr = {
   芙宁娜: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 95, phy: 0, recharge: 75, heal: 95 },
   夏洛蒂: { hp: 0, atk: 85, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 100, heal: 100 },
   娜维娅: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
-  夏沃蕾: { hp: 100, atk: 0, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 55, heal: 95 },
-  闲云: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 75, heal: 95 },
+  夏沃蕾: { hp: 100, atk: 0, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 55, heal: 55 },
+  闲云: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 75, heal: 75 },
   嘉明: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   千织: { hp: 0, atk: 50, def: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   阿蕾奇诺: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 30, heal: 0 },
@@ -90,5 +90,6 @@ export const usefulAttr = {
   艾梅莉埃: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 55, heal: 0 },
   卡齐娜: { hp: 0, atk: 0, def: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 75, heal: 0 },
   玛拉妮: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 85, dmg: 100, phy: 0, recharge: 45, heal: 0 },
-  基尼奇: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 50, heal: 0 }
+  基尼奇: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 50, heal: 0 },
+  希诺宁: { hp: 0, atk: 0, def: 100, cpct: 30, cdmg: 30, mastery: 0, dmg: 80, phy: 0, recharge: 100, heal: 100 }
 }

--- a/resources/meta-gs/character/希格雯/artis.js
+++ b/resources/meta-gs/character/希格雯/artis.js
@@ -1,0 +1,12 @@
+import { usefulAttr } from "../../artifact/artis-mark.js"
+
+export default function ({ cons, rule, def }) {
+    if (cons === 6) {
+        let particularAttr = JSON.parse(JSON.stringify(usefulAttr['希格雯']));
+        particularAttr.dmg = 100;
+        particularAttr.recharge = 75;
+        particularAttr.heal = 90;
+        return rule('希格雯-满命', particularAttr);
+    }
+    return def(usefulAttr['希格雯']);
+}

--- a/resources/meta-gs/character/芙宁娜/artis.js
+++ b/resources/meta-gs/character/芙宁娜/artis.js
@@ -2,7 +2,9 @@ import { usefulAttr } from "../../artifact/artis-mark.js"
 
 export default function ({ cons, rule, def }) {
     if (cons === 6) {
-      return rule('芙宁娜-满命', { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 45, dmg: 100, phy: 0, recharge: 75, heal: 95 })
+        let particularAttr = JSON.parse(JSON.stringify(usefulAttr['芙宁娜']));
+        particularAttr.mastery = 45;
+        return rule('芙宁娜-满命', particularAttr);
     }
-    return def(usefulAttr['芙宁娜'])
-  }
+    return def(usefulAttr['芙宁娜']);
+}


### PR DESCRIPTION
敌人默认等级，从91提高至103（配合世界等级9）。

降低夏沃蕾和闲云的治疗权重（防止分数溢出）。

新增希诺宁的评分权重。

添加希格雯满命情况下的评分权重。

优化芙宁娜满命情况下的评分权重部分的代码。