### PR TITLE
添加原神风属性染色伤害计算支持

### DIFF
--- a/models/Avatar.js
+++ b/models/Avatar.js
@@ -316,6 +316,14 @@ export default class Avatar extends Base {
     }
     let attr = this._attr = this._attr || Attr.create(this)
     this.attr = attr.calc()
+    if (this.game === 'gs') {
+      let artisMain = this.artis?.artis['4']?.main || {}
+      for (let key of ['pyro', 'hydro', 'electro', 'cryo']) 
+        if (artisMain.key === key)
+          this.attr[key] = artisMain.value
+        else      
+          this.attr[key] = 0
+    }
     this.base = attr.getBase()
   }
 

--- a/models/Avatar.js
+++ b/models/Avatar.js
@@ -323,6 +323,9 @@ export default class Avatar extends Base {
           this.attr[key] = artisMain.value
         else      
           this.attr[key] = 0
+      if (artisMain.key === 'anemo')
+        for (let key of ['pyro', 'hydro', 'electro', 'cryo'])
+          this.attr[key] = -artisMain.value
     }
     this.base = attr.getBase()
   }

--- a/models/dmg/DmgAttr.js
+++ b/models/dmg/DmgAttr.js
@@ -56,6 +56,23 @@ let DmgAttr = {
       }
     })
 
+    if (game === 'gs') 
+      lodash.forEach('pyro,hydro,electro,cryo'.split(','), (key) => {
+        ret[key] = ret[key] || {
+          pct: 0, // 倍率加成
+          multi: 0, // 独立倍率乘区加成，宵宫E等
+  
+          plus: 0, // 伤害值提高
+          dmg: attr[key] || 0, // 伤害提高
+          enemydmg: 0, // 承受伤害提高
+          cpct: 0, // 暴击提高
+          cdmg: 0, // 爆伤提高
+  
+          def: 0, // 防御降低
+          ignore: 0 // 无视防御
+        }
+    })
+
     ret.enemy = ret.enemy || {
       def: 0, // 降低防御
       ignore: 0, // 无视防御
@@ -198,7 +215,7 @@ let DmgAttr = {
         title = title.replace(`[${key}]`, Format.comma(val, 1))
 
         // 技能提高
-        let tRet = /^(a|a2|a3|e|q|t|dot|break)(Def|Ignore|Dmg|Enemydmg|Plus|Pct|Cpct|Cdmg|Multi)$/.exec(key)
+        let tRet = /^(a|a2|a3|e|q|t|dot|break|pyro|electro|cryo|hydro)(Def|Ignore|Dmg|Enemydmg|Plus|Pct|Cpct|Cdmg|Multi)$/.exec(key)
         if (tRet) {
           attr[tRet[1]][tRet[2].toLowerCase()] += val * 1 || 0
           return

--- a/models/dmg/DmgBuffs.js
+++ b/models/dmg/DmgBuffs.js
@@ -95,6 +95,17 @@ let DmgBuffs = {
             title: `${sets.name}${num}：${buff.elem}` + elebuff.title
           })
         }
+        else if (game === 'gs' && buff.elem === '风') {
+          let elebuff = lodash.cloneDeep(buff)
+          elebuff.data.pyroDmg = elebuff.data.hydroDmg = elebuff.data.cryoDmg = elebuff.data.electroDmg = -buff.data.dmg
+          delete elebuff.isStatic
+          delete elebuff.data.dmg
+          delete elebuff.elem
+          retBuffs.push({
+            ...elebuff,
+            title: `${sets.name}${num}：${buff.elem}` + elebuff.title
+          })
+        }
       })
     })
     return retBuffs

--- a/models/dmg/DmgBuffs.js
+++ b/models/dmg/DmgBuffs.js
@@ -70,16 +70,29 @@ let DmgBuffs = {
   // 圣遗物Buff
   getArtisBuffs (artis = {}, game = 'gs') {
     let retBuffs = []
+    const elemMap = { '雷': 'electro', '火': 'pyro', '冰': 'cryo', '水': 'hydro' }
     ArtifactSet.eachSet(artis, (sets, num) => {
       let buffs = ArtifactSet.getArtisSetBuff(sets.name, num, game)
       if (lodash.isPlainObject(buffs)) {
         buffs = [buffs]
       }
       lodash.forEach(buffs, (buff) => {
-        if (buff && !buff.isStatic) {
+        if (!buff) return
+        if (!buff.isStatic) {
           retBuffs.push({
             ...buff,
             title: `${sets.name}${num}：` + buff.title
+          })
+        }
+        else if (buff.elem in elemMap) {
+          let elebuff = lodash.cloneDeep(buff)
+          elebuff.data[`${elemMap[buff.elem]}Dmg`] = buff.data.dmg
+          delete elebuff.isStatic
+          delete elebuff.data.dmg
+          delete elebuff.elem
+          retBuffs.push({
+            ...elebuff,
+            title: `${sets.name}${num}：${buff.elem}` + elebuff.title
           })
         }
       })

--- a/models/dmg/DmgCalc.js
+++ b/models/dmg/DmgCalc.js
@@ -46,10 +46,8 @@ let DmgCalc = {
     if (ele === 'phy') {
       dmgNum = (1 + phy.base / 100 + phy.plus / 100 + dynamicPhy / 100)
     }
-    else if (game === 'gs' && talent) 
-      for (let key of ['pyro', 'hydro', 'electro', 'cryo']) 
-        if (talent.includes(key)) 
-          dmgNum = 1
+
+    if (/pyro|hydro|electro|cryo/.test(talent)) dmgNum = 1
 
     // 易伤区
     let enemydmgNum = 1
@@ -137,7 +135,7 @@ let DmgCalc = {
       let reactionElement = attr.element
       const eleMap = { pyro: '火', hydro: '水', electro: '雷', cryo: '冰' }
       Object.keys(eleMap).forEach(key => {
-        if (talent.includes(key)) reactionElement = eleMap[key];        
+        if (new RegExp(key).test(talent)) reactionElement = eleMap[key];        
       })
 
       eleNum = isEle ? DmgMastery.getBasePct(ele, reactionElement) : 1
@@ -277,7 +275,7 @@ let DmgCalc = {
         // 星铁meta数据天赋为百分比前数字
         pctNum = pctNum * 100
       }
-      if (game === 'gs' && talent.includes('color')) {
+      if (game === 'gs' && /color/.test(talent)) {
         let dmgRet = { max: 1e8, avg: 1e8 }
         for (let key of ['pyro', 'hydro', 'electro', 'cryo']) {
           let newTalent = talent.replace('color', key)

--- a/models/dmg/DmgCalc.js
+++ b/models/dmg/DmgCalc.js
@@ -46,6 +46,10 @@ let DmgCalc = {
     if (ele === 'phy') {
       dmgNum = (1 + phy.base / 100 + phy.plus / 100 + dynamicPhy / 100)
     }
+    else if (game === 'gs' && talent) 
+      for (let key of ['pyro', 'hydro', 'electro', 'cryo']) 
+        if (talent.includes(key)) 
+          dmgNum = 1
 
     // 易伤区
     let enemydmgNum = 1
@@ -130,7 +134,13 @@ let DmgCalc = {
     let eleNum = 1
     let eleBase = 1
     if (game === 'gs') {
-      eleNum = isEle ? DmgMastery.getBasePct(ele, attr.element) : 1
+      let reactionElement = attr.element
+      const eleMap = { pyro: '火', hydro: '水', electro: '雷', cryo: '冰' }
+      Object.keys(eleMap).forEach(key => {
+        if (talent.includes(key)) reactionElement = eleMap[key];        
+      })
+
+      eleNum = isEle ? DmgMastery.getBasePct(ele, reactionElement) : 1
       eleBase = isEle ? 1 + attr[ele] / 100 + DmgMastery.getMultiple(ele, calc(attr.mastery)) : 1
     }
 
@@ -266,6 +276,15 @@ let DmgCalc = {
       if (game === 'sr') {
         // 星铁meta数据天赋为百分比前数字
         pctNum = pctNum * 100
+      }
+      if (game === 'gs' && talent.includes('color')) {
+        let dmgRet = { max: 1e8, avg: 1e8 }
+        for (let key of ['pyro', 'hydro', 'electro', 'cryo']) {
+          let newTalent = talent.replace('color', key)
+          let dmgTmp = DmgCalc.calcRet({ pctNum, talent: newTalent, ele, basicNum, mode, dynamicData }, data)
+          if (dmgTmp.avg < dmgRet.avg) dmgRet = dmgTmp
+        }
+        return dmgRet
       }
       return DmgCalc.calcRet({ pctNum, talent, ele, basicNum, mode, dynamicData }, data)
     }

--- a/models/dmg/DmgCalc.js
+++ b/models/dmg/DmgCalc.js
@@ -47,8 +47,6 @@ let DmgCalc = {
       dmgNum = (1 + phy.base / 100 + phy.plus / 100 + dynamicPhy / 100)
     }
 
-    if (/pyro|hydro|electro|cryo/.test(talent)) dmgNum = 1
-
     // 易伤区
     let enemydmgNum = 1
     if (game === 'sr') {

--- a/resources/meta-gs/artifact/calc.js
+++ b/resources/meta-gs/artifact/calc.js
@@ -1,14 +1,14 @@
 const attr = function (key, val, elem = '', unit = '%') {
   const keyMap = {
-    hp: '生命值',
+    hpPct: '生命值',
     hpPlus: '生命值',
-    atk: '攻击力',
-    def: '防御力',
+    atkPct: '攻击力',
+    defPct: '防御力',
     cpct: '暴击率',
     dmg: '元素伤害',
     phy: '物理伤害',
     shield: '护盾强效',
-    heal: '治疗',
+    heal: '治疗加成',
     mastery: '元素精通'
   }
   let ret = {


### PR DESCRIPTION
用法：
表示某种颜色的染色伤害
```
dmg: ({ talent }, dmg) => dmg(talent.e['焕光追影弹伤害'], 'a2,pyro')
```
表示水火蒸发/冰火融化/雷激化染色伤害
```
dmg: ({ talent }, dmg) => dmg(talent.e['焕光追影弹伤害'], 'a2,pyro', 'vaporize')
```
表示四种染色伤害里最低者
```
dmg: ({ talent }, dmg) => dmg(talent.e['焕光追影弹伤害'], 'a2,color')
```
暂未添加各类check型buff的转化，可以和其他buff一样添加一个pyroDmg予以解决