### PR TITLE
添加乱破仪器评分计算逻辑

### DIFF
--- a/resources/meta-sr/artifact/artis-mark.js
+++ b/resources/meta-sr/artifact/artis-mark.js
@@ -3,6 +3,7 @@
  * 如character/${name}/artis.js下有角色自定义规则优先使用自定义
  */
 export const usefulAttr = {
+  乱破: { hp: 0, atk: 100, def: 0, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 0, recharge: 50, effPct: 0, effDef: 30, dmg: 0 },
   灵砂: { hp: 0, atk: 75, def: 0, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 100, recharge: 100, effPct: 0, effDef: 0, dmg: 0 },
   飞霄: { hp: 0, atk: 75, def: 0, speed: 75, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 0, dmg: 100 },
   云璃: { hp: 0, atk: 75, def: 0, speed: 0, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 0, dmg: 100 },


### PR DESCRIPTION
优化乱破的仪器评分计算逻辑，乱破本身不吃双爆，满命其实也不吃双爆，类似于流萤