### PR TITLE
Update CalendarSr.js 关于有时无法显示游戏内活动的信息

### DIFF
--- a/apps/wiki/CalendarSr.js
+++ b/apps/wiki/CalendarSr.js
@@ -250,6 +250,7 @@ let CalSr = {
 
     lodash.forEach(listData.data.list[0].list, (ds) => CalSr.getList(ds, resultList, { ...dateList, now, timeMap, gachaImgs }))
     lodash.forEach(listData.data.pic_list[0].type_list[0].list, (ds) => CalSr.getList(ds, resultList, { ...dateList, now, timeMap, gachaImgs }))
+    lodash.forEach(listData.data.pic_list[0].type_list[1].list, (ds) => CalSr.getList(ds, resultList, { ...dateList, now, timeMap, gachaImgs }))
 
     let versionStartTime
     lodash.forEach(listData.data.list[0].list, (ds) => {


### PR DESCRIPTION
在获取listData时，网页api会在pic_list[0].type_list中返回两个列表，目前其中一个是annid为727，无banner，无title，其图像为 https://sdk-webstatic.mihoyo.com/upload/ann/2024/11/11/396a2a2cc8784148d8cc8dfb8629fd4c_6874583538831706317.jpg “在第八日启程 版本概览”，通常在pic_list[0].type_list[1]的位置出现，而另一个（pic_list[0].type_list[0]）是正常的游戏内活动公告。

多次测试后发现从api获取到的两个列表的顺序可能发生互换，从而导致不能读取到活动信息。因此只要两个都读取就不会发生此问题。