### PR TITLE
提高玛薇卡的精通权重；添加茜特菈莉自定义圣遗物权重规则

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -94,7 +94,7 @@ export const usefulAttr = {
   希诺宁: { hp: 0, atk: 0, def: 100, cpct: 30, cdmg: 30, mastery: 0, dmg: 80, phy: 0, recharge: 100, heal: 100 },
   恰斯卡: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 80, phy: 0, recharge: 40, heal: 0 },
   欧洛伦: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 50, dmg: 100, phy: 0, recharge: 75, heal: 0 },
-  玛薇卡: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 0, heal: 0 },
+  玛薇卡: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 85, dmg: 100, phy: 0, recharge: 0, heal: 0 },
   茜特菈莉: { hp: 0, atk: 30, def: 0, cpct: 30, cdmg: 30, mastery: 100, dmg: 80, phy: 0, recharge: 100, heal: 0 },
   蓝砚: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 30, dmg: 80, phy: 0, recharge: 75, heal: 0 }
 }

--- a/resources/meta-gs/character/茜特菈莉/artis.js
+++ b/resources/meta-gs/character/茜特菈莉/artis.js
@@ -1,0 +1,16 @@
+import { usefulAttr } from "../../artifact/artis-mark.js"
+
+export default function ({ attr, rule, def }) {
+    let title = []
+    let particularAttr = { ...usefulAttr['茜特菈莉'] }
+    if (attr.cpct * 2 + attr.cdmg > 200) {
+        title.push('战斗')
+        particularAttr.atk = 50
+        particularAttr.cpct = 100
+        particularAttr.cdmg = 100
+    }
+    if (title.length > 0) {
+        return rule(`茜特菈莉-${title.join('')}`, particularAttr)
+    }
+    return def(usefulAttr['茜特菈莉'])
+}


### PR DESCRIPTION
将玛薇卡的精通权重，从 75 提高至 85.
虽然火神融化率不是100%，但是同词条的情况下，精通沙的总伤依然稳稳大于攻击沙。

当茜特菈莉的双暴分大于200时，将茜特菈莉的双暴权重提高至100，攻击权重提高至50。