### PR TITLE
添加玛薇卡伤害计算；添加梦见月瑞希圣遗物评分权重；添加铁道新遗器

### DIFF
--- a/models/attr/AttrData.js
+++ b/models/attr/AttrData.js
@@ -139,6 +139,27 @@ class AttrData extends Base {
       }
     })
     ret._calc = true
+
+    /**
+     * 提取并赋值角色静态的攻击、防御、生命的百分比加成总数值
+     * 包括但不限于圣遗物主副词条之和
+     * 圣遗物常驻加成，如追忆2、角斗士2等
+     * 武器副词条
+     * 角色突破加成等等
+     */
+    let staticAttrPct = {
+      atkPct: 0,
+      defPct: 0,
+      hpPct: 0
+    }
+    let _attr = this._attr
+    if (_attr) {
+      lodash.forEach(['atk', 'def', 'hp'], (key) => {
+        staticAttrPct[key + 'Pct'] += _attr[key]['pct']
+      })
+    }
+    ret.staticAttrPct = staticAttrPct
+    
     return ret
   }
 

--- a/models/dmg/DmgAttr.js
+++ b/models/dmg/DmgAttr.js
@@ -75,6 +75,7 @@ let DmgAttr = {
       ret.refine = ((weapon.affix || ret.refine || 1) * 1 - 1) || 0 // 武器精炼
       ret.multi = 0 // 倍率独立乘区
       ret.kx = 0 // 敌人抗性降低
+      ret.staticAttrPct = attr.staticAttrPct
       if (game === 'gs') {
         ret.vaporize = 0 // 蒸发
         ret.melt = 0 // 融化
@@ -209,6 +210,14 @@ let DmgAttr = {
           attr[aRet[1]][aRet[2] ? aRet[2].toLowerCase() : 'plus'] += val * 1 || 0
           return
         }
+
+        // hp、atk、def的基础值增加时（例如玛薇卡2命在夜魂加持状态下时，基础攻击力提高200）
+        let bRet = /^(hp|atk|def)(Base)$/.exec(key)
+        if (bRet) {
+          attr[bRet[1]][bRet[2].toLowerCase()] += val * 1 || 0
+          attr[bRet[1]]['plus'] += val * attr['staticAttrPct'][bRet[1] + 'Pct'] / 100 || 0
+        }
+        
         if (key === 'enemyDef') {
           attr.enemy.def += val * 1 || 0
           return

--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -96,5 +96,6 @@ export const usefulAttr = {
   欧洛伦: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 50, dmg: 100, phy: 0, recharge: 75, heal: 0 },
   玛薇卡: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 85, dmg: 100, phy: 0, recharge: 0, heal: 0 },
   茜特菈莉: { hp: 0, atk: 30, def: 0, cpct: 30, cdmg: 30, mastery: 100, dmg: 80, phy: 0, recharge: 100, heal: 0 },
-  蓝砚: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 30, dmg: 80, phy: 0, recharge: 75, heal: 0 }
+  蓝砚: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 30, dmg: 80, phy: 0, recharge: 75, heal: 0 },
+  梦见月瑞希: { hp: 0, atk: 50, def: 0, cpct: 50, cdmg: 50, mastery: 100, dmg: 80, phy: 0, recharge: 45, heal: 95 }
 }

--- a/resources/meta-gs/character/玛薇卡/calc.js
+++ b/resources/meta-gs/character/玛薇卡/calc.js
@@ -1,0 +1,122 @@
+export const details = [{
+  title: '满战意E焚曜之环伤害',
+  params: { Ring: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['焚曜之环伤害'], 'e,nightsoul')
+},{
+  title: '满战意驰轮车重击循环伤害',
+  params: { Flamestrider: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['驰轮车重击循环伤害'], 'a2,nightsoul')
+},{
+  title: '满战意驰轮车重击循环融化伤害',
+  params: { Flamestrider: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['驰轮车重击循环伤害'], 'a2,nightsoul', 'melt')
+},{
+  title: '满战意Q技能伤害',
+  params: { Flamestrider: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['技能伤害'], 'q,nightsoul')
+},{
+  title: '满战意Q融化伤害',
+  params: { Flamestrider: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['技能伤害'], 'q,nightsoul', 'melt')
+},{
+  title: '班玛希茜满战意驰轮车重击循环融化伤害',
+  params: { team: true, Flamestrider: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.e['驰轮车重击循环伤害'], 'a2,nightsoul', 'melt')
+},{
+  title: '班玛希茜满战意Q融化伤害',
+  params: { team: true, Flamestrider: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['技能伤害'], 'q,nightsoul', 'melt')
+},{
+  title: '班玛希茜(高配)满战意Q融化伤害',
+  params: { team_best: true, Flamestrider: true },
+  dmg: ({ talent, attr }, dmg) => dmg(talent.q['技能伤害'], 'q,nightsoul', 'melt')
+}]
+
+export const defParams = { Nightsoul: true }
+export const defDmgIdx = 6
+export const mainAttr = 'atk,cpct,cdmg,mastery'
+
+export const buffs = [{
+  check: ({ params }) => params.Flamestrider === true,
+  title: '玛薇卡元素爆发：满战意施放元素爆发后，坠日斩伤害提升[qPlus]，驰轮车普通攻击伤害提升[aPlus]，驰轮车重击伤害提升[a2Plus]',
+  sort: 9,
+  data: {
+    qPlus: ({ talent, calc, attr }) => 200 * talent.q['坠日斩伤害提升'] * calc(attr.atk) / 100 ,
+    aPlus: ({ talent, calc, attr }) => 200 * talent.q['驰轮车普通攻击伤害提升'] * calc(attr.atk) / 100 ,
+    a2Plus: ({ talent, calc, attr }) => 200 * talent.q['驰轮车重击伤害提升'] * calc(attr.atk) / 100 ,
+  }
+},{
+  title: '玛薇卡天赋：队伍中的附近的角色触发「夜魂迸发」时，攻击力提升[atkPct]%',
+  data: {
+    atkPct: 30
+  }
+},{
+  title: '玛薇卡天赋：施放元素爆发后，如果拥有满层战意，则造成的伤害提升[dmg]%',
+  data: {
+    dmg: 40
+  }
+},{
+  title: '玛薇卡1命：获取战意后，玛薇卡的攻击力提升[atkPct]%',
+  cons: 1,
+  data: {
+    atkPct: 40
+  }
+},{
+  title: '玛薇卡2命：基础攻击力提升[atkBase]',
+  sort: 2,
+  cons: 2,
+  data: {
+    atkBase: 200
+  }
+},{
+  check: ({ params }) => params.Ring === true,
+  title: '玛薇卡2命：夜魂加持状态下时，焚曜之环附近的敌人的防御力降低[enemyDef]',
+  cons: 2,
+  data: {
+    enemyDef: 20
+  }
+},{
+  title: '玛薇卡2命：夜魂加持状态下时，普通攻击伤害提升[aPlus]，重击伤害提升[a2Plus]，元素爆发伤害提升[qPlus]',
+  sort: 9,
+  cons: 2,
+  data: {
+    aPlus: ({ calc, attr }) => calc(attr.atk) * 60 / 100,
+    a2Plus: ({ calc, attr }) => calc(attr.atk) * 90 / 100,
+    qPlus: ({ calc, attr }) => calc(attr.atk) * 120 / 100
+  }
+},{
+  title: '玛薇卡4命：施放元素爆发燔天之时后额外获得[dmg]%伤害加成 ',
+  cons: 4,
+  data: {
+    dmg: 10
+  }
+},{
+  check: ({ params }) => params.Flamestrider === true,
+  title: '玛薇卡6命：驾驶驰轮车时使附近的敌人的防御力降低[enemyDef]% ',
+  cons: 6,
+  data: {
+    enemyDef: 20
+  }
+},{
+  check: ({ params }) => params.team === true,
+  title: '班玛希茜：班尼特6命风鹰剑宗室4、希诺宁0+0勇者4、茜特菈莉0+0',
+  data: {
+    atkPlus: 1203,
+    atkPct: 25 + 20,
+    dmg: 15 + 40,
+    kx: 36 + 20
+  }
+},{
+  check: ({ params }) => params.team_best === true,
+  title: '班玛希茜（高配）：班尼特6命风鹰剑宗室4、希诺宁6+5教官4、茜特菈莉6+5勇者4（茜特菈莉精通最终面板，按1500计）',
+  data: {
+    atkPlus: 1203,
+    atkPct: 25 + 20 + 45,
+    dmg: 15 + 40 + 51.2 + 56 + 60,
+    kx: 45 + 20 + 20,
+    qPlus: 1500 * 2,
+    mastery: 250 + 120
+  }
+}]
+
+export const createdBy = '冰翼'

--- a/resources/meta-sr/artifact/calc.js
+++ b/resources/meta-sr/artifact/calc.js
@@ -336,5 +336,14 @@ export default {
         qDmg: 20
       }
     }
+  },
+  凯歌祝捷的英豪: {
+    2: attr('atkPct', 12),
+    4: [attr('speedPct', 6), {
+      title: '装备者的忆灵攻击时，装备者和忆灵的暴击伤害提高[cdmg]%',
+      data: {
+        cdmg: 30
+      }
+    }]
   }
 }


### PR DESCRIPTION
这次更新为了配合火神2命，在伤害计算方面，添加了对基础类数值（攻击、防御、生命）变动的支持。
如有自行编写伤害插件的人，可以像本次更新里的玛薇卡伤害计算那样，在 buff 里添加 **atkBase：200** 即可。
且为了防止后续出现诸如基础防御、基础生命之类的变动，这里也提前对这两者做了支持。
如以后出现基础防御力+200，则在伤害计算 buff 里添加 **defBase** 即可。

因为很多人用 liangshi 插件，这里提一嘴。
在liangshi插件 damage/liangshi-gs/玛薇卡/CalcBuff.js 这个文件里。
它的第 **19** 行代码（如下图所示）里的 **atkBase：200** 原本仅做展示作用。
它的真正起作用的代码是第 **20** 行的代码。
然而 ackPct 这个代表着攻击百分比数值的变量，实际上只包含了武器被动和人物天赋内的部分，并不包含圣遗物主副词条、武器副词条、圣遗物套装效果（常驻）等等。
所以才有此更新。
**安装了 liangshi 插件的人，可以自行在本次 miao-plugin 更新后，到对应 liangshi 文件里把第 20 行的代码删除（和第19行末尾的逗号）。或等待 liangshi 插件自行更新。**

[
![QQ20250207-213414](https://github.com/user-attachments/assets/9a3c2b54-9d6a-404b-adf8-5d306f93abe6)
](url)