### PR TITLE
添加阿格莱雅等5人的铁道角色圣遗物评分权重，修正珐露珊伤害计算

### DIFF
--- a/resources/meta-gs/character/珐露珊/calc.js
+++ b/resources/meta-gs/character/珐露珊/calc.js
@@ -36,4 +36,13 @@ export const buffs = [{
   data: {
     dmg: ({ talent }) => talent.q['风元素伤害加成']
   }
+}, {
+  title: '珐露珊天赋：处于「祈风之赐」效果下角色的普通攻击、重击、下落攻击、元素战技或元素爆发对敌人造成风元素伤害时，基于珐露珊基础攻击力的32%，提高造成的伤害。',
+  data: {
+    aPlus: ({ attr }) => attr.atk.base * 32 / 100 ,
+    a2Plus: ({ attr }) => attr.atk.base * 32 / 100 ,
+    a3Plus: ({ attr }) => attr.atk.base * 32 / 100 ,
+    ePlus: ({ attr }) => attr.atk.base * 32 / 100 ,
+    qPlus: ({ attr }) => attr.atk.base * 32 / 100
+  }
 }]

--- a/resources/meta-sr/artifact/artis-mark.js
+++ b/resources/meta-sr/artifact/artis-mark.js
@@ -3,6 +3,11 @@
  * 如character/${name}/artis.js下有角色自定义规则优先使用自定义
  */
 export const usefulAttr = {
+  阿格莱雅: { hp: 75, atk: 0, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 100 },
+  大黑塔: { hp: 75, atk: 0, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 100 },
+  忘归人: { hp: 50, atk: 0, def: 50, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 0, recharge: 100, effPct: 100, effDef: 0, dmg: 0 },
+  星期日: { hp: 75, atk: 0, def: 75, speed: 100, cpct: 0, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 50, dmg: 0 },
+  乱破: { hp: 30, atk: 100, def: 30, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 0, recharge: 0, effPct: 0, effDef: 30, dmg: 0 },
   灵砂: { hp: 0, atk: 75, def: 0, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 100, recharge: 100, effPct: 0, effDef: 0, dmg: 0 },
   飞霄: { hp: 0, atk: 75, def: 0, speed: 75, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 0, dmg: 100 },
   云璃: { hp: 0, atk: 75, def: 0, speed: 0, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 0, dmg: 100 },


### PR DESCRIPTION
添加阿格莱雅、大黑塔、忘归人、星期日、乱破，共5人的铁道角色圣遗物评分权重。

修正珐露珊伤害计算时的天赋缺失。