### PR TITLE
修正恰斯卡伤害BUG，修正阿格莱雅、大黑塔的评分权重，新增茜特菈莉、恰斯卡伤害计算项

### DIFF
--- a/models/attr/AttrData.js
+++ b/models/attr/AttrData.js
@@ -150,13 +150,15 @@ class AttrData extends Base {
     let staticAttrPct = {
       atkPct: 0,
       defPct: 0,
-      hpPct: 0
+      hpPct: 0,
+      dmgPct: 0
     }
     let _attr = this._attr
     if (_attr) {
       lodash.forEach(['atk', 'def', 'hp'], (key) => {
         staticAttrPct[key + 'Pct'] += _attr[key]['pct']
       })
+      staticAttrPct.dmgPct += _attr.dmg.plus
     }
     ret.staticAttrPct = staticAttrPct
     

--- a/models/dmg/DmgCalc.js
+++ b/models/dmg/DmgCalc.js
@@ -49,10 +49,13 @@ let DmgCalc = {
     }
 
     if (/^scene,.*/.test(ele) || /.*,scene$/.test(ele) || ele === 'scene') {
-      dmgNum = 1
-       if (ele !== 'scene') {
-         ele = ele.replace(/(,)?scene(,)?/g, "")
-       }
+      let dmgPct = attr.staticAttrPct.dmgPct / 100
+      if (dmgPct > 0) {
+        dmgNum = (dmgNum - dmgPct) < 1 ? 1 : (dmgNum - dmgPct)
+      }
+      if (ele !== 'scene') {
+        ele = ele.replace(/(,)?scene(,)?/g, "")
+      }
     }
 
     // 易伤区

--- a/resources/meta-gs/character/恰斯卡/calc.js
+++ b/resources/meta-gs/character/恰斯卡/calc.js
@@ -8,6 +8,22 @@ export const details = [{
   params: { ShadowSpirit: true, AllShadowhuntShell: true },
   dmg: ({ talent }, dmg) => dmg(talent.e['焕光追影弹伤害'], 'a2,nightsoul', 'scene')
 },{
+  title: 'E焕光追影弹最低增幅伤害',
+  dmgKey: 'z',
+  params: { ShadowSpirit: true, AllShadowhuntShell: true },
+  dmg: ({ talent }, dmg) => dmg(talent.e['焕光追影弹伤害'], 'a2,nightsoul', 'scene,vaporize')
+},{
+  title: 'E焕光追影弹最高增幅伤害',
+  dmgKey: 'z',
+  params: { ShadowSpirit: true, AllShadowhuntShell: true },
+  dmg: ({ talent }, dmg) => {
+    let ret = dmg(talent.e['焕光追影弹伤害'], 'a2,nightsoul', 'scene,vaporize')
+    return {
+      dmg: ret.dmg * 2 / 1.5,
+      avg: ret.avg * 2 / 1.5
+    }
+  }
+},{
   title: 'Q裂风索魂弹伤害',
   dmg: ({ talent }, dmg) => dmg(talent.q['裂风索魂弹伤害'], 'q,nightsoul')
 },{
@@ -30,7 +46,7 @@ export const details = [{
 }]
 
 export const defParams = { Nightsoul: true }
-export const defDmgIdx = 1
+export const defDmgIdx = 3
 export const mainAttr = 'atk,cpct,cdmg,mastery'
 
 export const buffs = [{

--- a/resources/meta-gs/character/茜特菈莉/calc.js
+++ b/resources/meta-gs/character/茜特菈莉/calc.js
@@ -17,6 +17,10 @@ export const details = [{
   params: { windstorm: true },
   dmg: ({ talent }, dmg) => dmg(talent.q['冰风暴伤害'], 'q,nightsoul', 'melt')
 }, {
+  title: '双火班希Q融化伤害',
+  params: { windstorm: true, team: true },
+  dmg: ({ talent }, dmg) => dmg(talent.q['冰风暴伤害'], 'q,nightsoul', 'melt')
+}, {
   check: ({ cons }) => cons >= 1,
   title: '「星刃」基础伤害提升值',
   dmg: ({ calc, attr }) => {
@@ -49,6 +53,14 @@ export const buffs = [{
   cons: 6,
   data: {
     dmg: 2.5 * 40
+  }
+}, {
+  check: ({ params }) => params.team === true,
+  title: '双火班希：班尼特6命风鹰剑宗室4，希诺宁0+0',
+  data: {
+    atkPlus: 1203,
+    atkPct: 25 + 20,
+    kx: 36,
   }
 }]
 

--- a/resources/meta-sr/artifact/artis-mark.js
+++ b/resources/meta-sr/artifact/artis-mark.js
@@ -3,8 +3,8 @@
  * 如character/${name}/artis.js下有角色自定义规则优先使用自定义
  */
 export const usefulAttr = {
-  阿格莱雅: { hp: 75, atk: 0, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 100 },
-  大黑塔: { hp: 75, atk: 0, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 100 },
+  阿格莱雅: { hp: 0, atk: 75, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 100 },
+  大黑塔: { hp: 0, atk: 75, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 100 },
   忘归人: { hp: 50, atk: 0, def: 50, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 0, recharge: 100, effPct: 100, effDef: 0, dmg: 0 },
   星期日: { hp: 75, atk: 0, def: 75, speed: 100, cpct: 0, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 50, dmg: 0 },
   乱破: { hp: 30, atk: 100, def: 30, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 0, recharge: 0, effPct: 0, effDef: 30, dmg: 0 },


### PR DESCRIPTION
修正恰斯卡伤害未计入黑曜2件套加成的BUG。

阿格莱雅、大黑塔攻击权重应为75，生命权重应为0。

茜特菈莉新增【双火班希Q融化伤害】。

恰斯卡新增【E焕光追影弹最低、最高增幅伤害】。