### PR TITLE
梦见月伤害计算buff修正，剧变反应伤害计算公式修正 

### DIFF
--- a/models/dmg/DmgCalc.js
+++ b/models/dmg/DmgCalc.js
@@ -193,7 +193,7 @@ let DmgCalc = {
       case 'burgeon':
       case 'hyperBloom': {
         eleBase *= eleBaseDmg[level]
-        ret = { avg: (eleBase + fyplus) * eleNum * kNum }
+        ret = { avg: (eleBase * eleNum + fyplus) * kNum }
         break
       }
 

--- a/resources/meta-gs/character/梦见月瑞希/calc.js
+++ b/resources/meta-gs/character/梦见月瑞希/calc.js
@@ -45,7 +45,7 @@ export const buffs = [{
   cons: 1,
   sort: 9,
   data: {
-    fyplus: ({ attr, calc }) => calc(attr.mastery) * 900 / 100
+    fyplus: ({ attr, calc }) => calc(attr.mastery) * 1100 / 100
   }
 }, {
   title: '瑞希被动：其他的火、水、冰雷、元素角色的攻击命中敌人时,元素精通提升[mastery]点',


### PR DESCRIPTION
梦见月伤害计算buff修正——1命应为 1100 倍率，而不是 900。
剧变反应伤害计算公式修正。