### PR TITLE
【星铁】添加椒丘伤害计算；修正缇宝伤害计算BUG

### DIFF
--- a/resources/meta-sr/character/椒丘/calc.js
+++ b/resources/meta-sr/character/椒丘/calc.js
@@ -1,0 +1,67 @@
+export const details = [{
+  title: '普攻伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['技能伤害'], 'a')
+}, {
+  title: '战技伤害·主目标',
+  dmg: ({ talent }, dmg) => dmg(talent.e['目标伤害'], 'e')
+}, {
+  title: '战技伤害·相邻目标',
+  dmg: ({ talent }, dmg) => dmg(talent.e['相邻目标伤害'], 'e')
+}, {
+  title: '终结技伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'], 'q')
+}, {
+  title: '天赋持续伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.t['持续伤害'], 't')
+}]
+
+export const defDmgIdx = 4
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const buffs = [{
+  title: '椒丘终结技：敌方目标受到的终结技伤害提高[qEnemydmg]%',
+  data: {
+    qEnemydmg: ({ talent }) => talent.q['终结技伤害提高'] * 100
+  }
+}, {
+  title: '椒丘天赋：满层【烬煨】使敌人受到的伤害提高[enemydmg]%',
+  data: {
+    enemydmg: ({ talent, cons }) => {
+      let num = cons < 6 ? 4 : 8
+      return (talent.t['1层伤害提高'] + talent.t['叠加伤害提高'] * num) * 100
+    }
+  }
+}, {
+  title: '椒丘额外能力：椒丘效果命中大于80%时，每超过15%，则额外提高60%攻击力，最高不超过240%。当前额外提高[atkPct]%攻击力。',
+  tree: 2,
+  data: {
+    atkPct: ({ calc, attr }) => {
+      let num = Math.min(Math.floor((calc(attr.effPct) - 80) / 15), 4)
+      if (num > 0) {
+        return num * 60
+      } else {
+        return 0
+      }
+    }
+  }
+}, {
+  title: '椒丘1命：我方目标对处于【烬煨】状态的敌方目标造成的伤害提高[dmg]%',
+  cons: 1,
+  data: {
+    dmg: 40
+  }
+}, {
+  title: '椒丘2命：敌方目标处于【烬煨】状态时，【烬煨】对其造成的火属性持续伤害倍率提高[tPct]%',
+  cons: 2,
+  data: {
+    tPct: 300
+  }
+}, {
+  title: '椒丘6命：满层【烬煨】会使目标的全属性抗性降低[kx]%',
+  cons: 6,
+  data: {
+    kx : 9 * 3
+  }
+}]
+
+export const createdBy = '冰翼'

--- a/resources/meta-sr/character/缇宝/calc.js
+++ b/resources/meta-sr/character/缇宝/calc.js
@@ -27,7 +27,7 @@ export const buffs = [{
 }, {
   title: '缇宝终结技：敌方目标受到的伤害提高[dmg]%',
   data: {
-    dmg: ({ talent }) => talent.q['受到的伤害提高'] * 100
+    enemydmg: ({ talent }) => talent.q['受到的伤害提高'] * 100
   }
 }, {
   title: '缇宝额外能力：施放天赋的追加攻击后，缇宝造成的伤害提高72%，该效果最多叠加3层',
@@ -39,7 +39,7 @@ export const buffs = [{
   title: '缇宝额外能力：缇宝的生命上限提高，提高数值等同于我方全体角色生命上限之和的9%',
   tree: 2,
   data: {
-    hpPct: 9
+    hpPlus: ({ calc, attr }) => calc(attr.hp) * 9 / 100
   }
 }, {
   title: '缇宝4魂：【神启】持续期间，我方全体造成伤害时无视目标[ignore]%的防御',


### PR DESCRIPTION
修正缇宝伤害计算BUG——
1、缇宝终结技——使敌方受到伤害提高。应为易伤区，而不是增伤区。
2、缇宝额外能力应为提高生命数值上限9%，而不是生命倍率。

添加椒丘伤害计算。