### PR TITLE
Update CalendarSr.js

### DIFF
--- a/apps/wiki/CalendarSr.js
+++ b/apps/wiki/CalendarSr.js
@@ -186,6 +186,10 @@ let CalSr = {
       type = 'character'
       extra.sort = 1
       banner = gachaImgs.shift()
+    } else if (/版本活动跃迁/.test(title)) { //权宜之计，当前版本把多个池子塞在同一个公告里发布，姑且这么用着罢（）
+      type = 'character'
+      extra.sort = 1
+      banner = gachaImgs.shift()
     } else if (/无名勋礼/.test(title)) {
       type = 'pass'
     }


### PR DESCRIPTION
修复了卡池的显示。

权宜之计，当前版本把多个池子塞在同一个公告里发布然后呼之为“X.X版本活动跃迁”，不知道之后会怎么样，总之先把日历的卡池功能变成接近往日的状态。