### PR TITLE
添加三月七巡猎、貊泽伤害计算。调整伊安珊排名标准

### DIFF
--- a/resources/meta-gs/character/伊安珊/calc.js
+++ b/resources/meta-gs/character/伊安珊/calc.js
@@ -26,7 +26,7 @@ export const details = [{
 }]
 
 export const defParams = { Nightsoul: true }
-export const defDmgIdx = 3
+export const defDmgIdx = 2
 export const mainAttr = 'atk,cpct,cdmg'
 
 export const buffs = [{

--- a/resources/meta-sr/character/三月七·巡猎/calc.js
+++ b/resources/meta-sr/character/三月七·巡猎/calc.js
@@ -1,0 +1,28 @@
+export const details = [{
+  title: '强化普攻单次伤害',
+  params: { EnhancedBasicAtk: true },
+  dmg: ({ talent }, dmg) => dmg(talent.a2['技能伤害'], 'a')
+}, {
+  title: '终结技伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'], 'q')
+}]
+
+export const defDmgIdx = 0
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const buffs = [{
+  title: '三月七·巡猎天赋：充能大于等于7点时，三月七立即行动，造成的伤害提高[dmg]%',
+  cons: 1,
+  data: {
+    dmg: ({ talent }) => talent.t['伤害提高'] * 100
+  }
+}, {
+  check: ({ params }) => params.EnhancedBasicAtk === true,
+  title: '三月七·巡猎6魂：施放终结技后，下一次强化普攻造成的暴击伤害提高[aCdmg]%',
+  cons: 6,
+  data: {
+    aCdmg: 50
+  }
+}]
+
+export const createdBy = '冰翼'

--- a/resources/meta-sr/character/貊泽/calc.js
+++ b/resources/meta-sr/character/貊泽/calc.js
@@ -1,0 +1,47 @@
+export const details = [{
+  title: '普攻伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.a['技能伤害'], 'a')
+}, {
+  title: '战技伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e')
+}, {
+  title: '天赋附加伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.t['附加伤害'], 't')
+}, {
+  title: '天赋追加攻击伤害',
+  params: { FollowUpAttack: true },
+  dmg: ({ talent, cons }, dmg) => {
+    let num = cons === 6 ? 0.25 : 0
+    return dmg(talent.t['追加攻击伤害'] + num, 't')
+  }
+}, {
+  title: '终结技伤害',
+  params: { FollowUpAttack: true },
+  dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'], 'q')
+}]
+
+export const defDmgIdx = 3
+export const mainAttr = 'atk,cpct,cdmg'
+
+export const buffs = [{
+  check: ({ params }) => params.FollowUpAttack === true,
+  title: '貊泽天赋：施放终结技造成伤害时，被视为发动了追加攻击。【猎物】受到的追加攻击伤害提高[enemydmg]%',
+  tree: 3,
+  data: {
+    enemydmg: 25
+  }
+}, {
+  title: '貊泽2魂：我方全体目标对成为【猎物】的敌方目标造成伤害时，暴击伤害提高[cdmg]%',
+  cons: 1,
+  data: {
+    cdmg: 40
+  }
+}, {
+  title: '貊泽4魂：施放终结技时，貊泽造成的伤害提高[dmg]%',
+  cons: 4,
+  data: {
+    dmg: 20
+  }
+}]
+
+export const createdBy = '冰翼'


### PR DESCRIPTION
添加三月七巡猎、貊泽伤害计算。
调整伊安珊排名标准，将排名标准从“动能标识攻击力提升”变为“E后Q技能伤害”。