### PR TITLE
补充遐蝶伤害计算【by 其实雨很好】& 修正伊法6命额外秘药弹伤害计算 

### DIFF
--- a/apps/wiki/CharTalent.js
+++ b/apps/wiki/CharTalent.js
@@ -13,7 +13,7 @@ const CharTalent = {
         lodash.forEach(detail[key], (ds, idx) => {
           if (ds.desc) {
             if (key === 'talent' && ds.desc.split) {
-              let desc = CharTalent.getDesc(ds.desc, ds.tables, idx === 'a' || idx === 'a2' || idx === 'me' || idx === 'mt' ? 5 : 8)
+              let desc = CharTalent.getDesc(ds.desc, ds.tables, ("a,a2,me,me2,mt,mt1,mt2").split(",").includes(idx) ? 5 : 8)
               ds.desc = desc.desc
               ds.tables = desc.tables
             } else if (ds.desc.split) {

--- a/models/ProfileDmg.js
+++ b/models/ProfileDmg.js
@@ -47,7 +47,7 @@ export default class ProfileDmg extends Base {
     ret.talentLevel = talentData
     let detail = char.detail
     let { isSr, isGs } = this
-    lodash.forEach((isSr ? 'a,a2,e,e2,q,q2,t,me,mt' : 'a,e,q').split(','), (key) => {
+    lodash.forEach((isSr ? 'a,a2,e,e2,q,q2,t,me,me2,mt,mt1,mt2' : 'a,e,q').split(','), (key) => {
       let level = lodash.isNumber(talentData[key]) ? talentData[key] : (talentData[key]?.level || 1)
       let keyRet = /^(a|e|q)2$/.exec(key)
       if (keyRet) {

--- a/models/dmg/DmgCalc.js
+++ b/models/dmg/DmgCalc.js
@@ -170,7 +170,7 @@ let DmgCalc = {
       }
     }
 
-    let dmgBase = (mode === 'basic') ? basicNum + plusNum : atkNum * pctNum * (1 + multiNum) + plusNum
+    let dmgBase = (mode === 'basic') ? basicNum * (1 + multiNum) + plusNum : atkNum * pctNum * (1 + multiNum) + plusNum
     let ret = {}
 
     switch (ele) {

--- a/resources/meta-gs/character/伊法/calc.js
+++ b/resources/meta-gs/character/伊法/calc.js
@@ -15,7 +15,7 @@ export const details = [{
 }, {
   title: '6命额外秘药弹伤害',
   cons: 6,
-  dmg: ({ attr, calc }, { basic }) => basic(calc(attr.atk) * 160 / 100, 'a,nightsoul')
+  dmg: ({ attr, calc }, { basic }) => basic(calc(attr.atk) * 120 / 100, 'a,nightsoul')
 }]
 
 export const defParams = { Nightsoul: true }

--- a/resources/meta-sr/character/遐蝶/calc.js
+++ b/resources/meta-sr/character/遐蝶/calc.js
@@ -8,16 +8,39 @@ export const details = [{
   title: '战技伤害·相邻目标',
   dmg: ({ talent, calc, attr }, { basic }) => basic(calc(attr.hp) * talent.e['相邻目标伤害'], 'e')
 }, {
-  title: '强化战技伤害(遐蝶)',
-  dmg: ({ talent, cons,  calc, attr }, { basic }) => {
-    let num = cons > 0 ? 1.4 : 1
-    return basic(calc(attr.hp) * talent.e2['遐蝶伤害'] * num, 'e')
-  }
+  title: '强化战技伤害（遐蝶）',
+  params: { cons1: true },
+  dmg: ({ talent, cons, calc, attr }, { basic }) => basic(calc(attr.hp) * talent.e2['遐蝶伤害'], 'e')
 }, {
-  title: '强化战技伤害(死龙)',
-  dmg: ({ talent, cons,  calc, attr }, { basic }) => {
-    let num = cons > 0 ? 1.4 : 1
-    return basic(calc(attr.hp) * talent.e2['死龙伤害'] * num, 'e')
+  title: '强化战技伤害（死龙）',
+  params: { cons1: true },
+  dmg: ({ talent, cons, calc, attr }, { basic }) => basic(calc(attr.hp) * talent.e2['死龙伤害'], 'e')
+}, {
+  title: '忆灵天赋单次伤害',
+  params: { cons1: true },
+  dmg: ({ talent, calc, attr }, { basic }) => basic(calc(attr.hp) * talent.mt2['技能伤害'], 'mt')
+}, {
+  title: '忆灵技（爪痕）伤害',
+  params: { cons1: true },
+  dmg: ({ talent, calc, attr }, { basic }) => basic(calc(attr.hp) * talent.me['技能伤害'], 'me')
+}, {
+  title: '三次死龙焰息+死龙晦翼总伤害',
+  params: { cons1: true },
+  dmg: ({ talent, cons, attr, calc }, { basic }) => {
+    let cost = cons > 1 ? 4 : 2
+    let meDmg1 = basic(calc(attr.hp) * talent.me2["技能伤害"], "me", false, { dynamicDmg: 30 })
+    let meDmg2 = basic(calc(attr.hp) * talent.me2["二次释放伤害"], "me", false, { dynamicDmg: 60 })
+    let meDmg3 = basic(calc(attr.hp) * talent.me2["三次释放伤害"], "me", false, { dynamicDmg: 90 })
+    for (let i = 1; i < cost; i++) {
+      let dmg = basic(calc(attr.hp) * talent.me2["三次释放伤害"], "me", false, { dynamicDmg: 90 + 30 * i })
+      meDmg3.dmg += dmg.dmg
+      meDmg3.avg += dmg.avg
+    }
+    let meDmg4 = basic(calc(attr.hp) * talent.me2["灼掠幽墟的晦翼伤害"] * (cons === 6 ? 9 : 6), "mt", false, { dynamicDmg: 60 + 30 * cost })
+    return {
+      dmg: meDmg1.dmg + meDmg2.dmg + meDmg3.dmg + meDmg4.dmg,
+      avg: meDmg1.avg + meDmg2.avg + meDmg3.avg + meDmg4.avg
+    }
   }
 }]
 
@@ -35,8 +58,17 @@ export const buffs = [{
     kx: ({ talent }) => talent.q['抗性降低'] * 100
   }
 }, {
+  title: '忆灵天赋-震彻寂壤的怒啸：死龙被召唤时，我方全体造成的伤害提高[dmg]%',
+  data: {
+    dmg: 10
+  }
+}, {
+  check: ({ params }) => params.cons1 === true,
   title: '遐蝶1魂：敌方目标当前生命值小于等于自身生命上限50%时，强化战技对其造成的伤害为原伤害的140%',
-  cons: 1
+  cons: 1,
+  data: {
+    multi: 40
+  }
 }, {
   title: '遐蝶6魂：遐蝶与死龙造成伤害时，量子属性抗性穿透提高[kx]%',
   cons: 6,

--- a/resources/meta-sr/character/阿格莱雅/calc.js
+++ b/resources/meta-sr/character/阿格莱雅/calc.js
@@ -20,10 +20,7 @@ export const details = [{
 }, {
   title: 'Q后天赋附加伤害',
   params: { Supreme_Stance: true },
-  dmg: ({ talent, attr, calc }, { basic }) => {
-    let num = talent.t['附加伤害']
-    return basic(calc(attr.atk) * num)
-  }
+  dmg: ({ talent }, dmg) => dmg(talent.t['附加伤害'])
 }]
 
 export const defDmgIdx = 1


### PR DESCRIPTION
补充遐蝶【三次死龙焰息+死龙晦翼总伤害】by 其实雨很好。
修正伊法6命额外秘药弹伤害计算——倍率应为120%而不是160%；
优化阿格莱雅天赋附加伤害计算的代码。