### PR TITLE
修复角色按钮过多导致按钮行数过多的问题

### DIFF
--- a/models/Button.js
+++ b/models/Button.js
@@ -42,11 +42,14 @@ export default class Button {
 
   profileList(uid = "", charList = {}) {
     const button = [[]]
+    let count = 0
     for (const name in charList) {
+      if (count >= 10) break 
       const array = button[button.length-1]
       array.push({ text: `${name}面板`, callback: `${this.prefix}${name}面板${uid}` })
       if (array.length > 1)
         button.push([])
+      count++
     }
     if (!button[0].length)
       button[0] = [


### PR DESCRIPTION
当角色数量超过10个时，角色按钮会超过5行（每行2个），QQBot最多只支持五行按钮，影响界面美观和用户体验。 本次修改在profileList方法中限制最多只显示10个角色按钮，确保按钮不会超过5行，提升了界面整洁性和可用性。