### PR TITLE
fix: 修复查看角色面板时会在根目录生成额外文件的问题 fix #968

### DIFF
--- a/apps/profile/ProfileDetail.js
+++ b/apps/profile/ProfileDetail.js
@@ -245,7 +245,7 @@ let ProfileDetail = {
       data,
       attr,
       elem: char.elem,
-      path: char.weapon,
+      hsr_paths: char.weapon,
       dmgCalc,
       artisDetail,
       artisKeyTitle,

--- a/resources/character/profile-detail.html
+++ b/resources/character/profile-detail.html
@@ -112,7 +112,7 @@
   <div class="profile-detail">
     {{if game === 'sr'}}
     <!-- 【 星铁 天赋+行迹 】 -->
-    {{if path === '记忆'}}
+    {{if hsr_paths === '记忆'}}
     {{set talentMap = {a: '普攻', e: '战技', t:'天赋', q: '爆发', me: '忆灵技', mt: '忆灵天赋'} }}
     <div class="sr-talent memosprite">
     {{else}}


### PR DESCRIPTION
修复pr（<https://github.com/yoimiya-kokomi/miao-plugin/pull/950>）产生的问题

> https://github.com/yoimiya-kokomi/miao-plugin/issues/968
> 查看面板时在根目录下会生成额外文件

经测试，改完之后忆灵技可以正常显示，且不再在根目录生成文件，看他当时的提交记录，就这俩地方，应该没有其他问题了
