### PR TITLE
添加赛飞儿、风堇（满命）的圣遗物评分规则；修正光锥【生命当付之一炬】的buff名称【by 其实雨很好】

### DIFF
--- a/resources/meta-sr/artifact/artis-mark.js
+++ b/resources/meta-sr/artifact/artis-mark.js
@@ -3,6 +3,7 @@
  * 如character/${name}/artis.js下有角色自定义规则优先使用自定义
  */
 export const usefulAttr = {
+  赛飞儿: { hp: 0, atk: 75, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 75, effDef: 0, dmg: 100 },
   风堇: { hp: 100, atk: 0, def: 0, speed: 100, cpct: 0, cdmg: 75, stance: 0, heal: 100, recharge: 100, effPct: 0, effDef: 50, dmg: 0 },
   那刻夏: { hp: 0, atk: 75, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 0, dmg: 100 },
   遐蝶: { hp: 100, atk: 0, def: 0, speed: 0, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 30, dmg: 100 },

--- a/resources/meta-sr/character/缇宝/calc.js
+++ b/resources/meta-sr/character/缇宝/calc.js
@@ -2,7 +2,7 @@ export const details = [{
   title: '普攻伤害',
   dmg: ({ talent, calc, attr }, { basic }) => basic(calc(attr.hp) * talent.a['技能伤害'], 'a')
 }, {
-  title: '天赋追加伤害',
+  title: '天赋追加攻击伤害',
   params: { cons6: true },
   dmg: ({ talent, calc, attr }, { basic }) => basic(calc(attr.hp) * talent.t['追加攻击伤害'], 't')
 }, {

--- a/resources/meta-sr/character/风堇/artis.js
+++ b/resources/meta-sr/character/风堇/artis.js
@@ -1,0 +1,10 @@
+import { usefulAttr } from "../../artifact/artis-mark.js"
+
+export default function ({ cons, rule, def }) {
+  let particularAttr = { ...usefulAttr['风堇'] }
+  if (cons == 6) {
+    particularAttr.cdmg = 100
+    return rule(`风堇-满命`, particularAttr)
+  }
+  return def(usefulAttr['风堇'])
+}

--- a/resources/meta-sr/weapon/智识/calc.js
+++ b/resources/meta-sr/weapon/智识/calc.js
@@ -124,7 +124,7 @@ export default function (staticIdx, keyIdx) {
       }
     ],
     生命当付之一炬: [
-      keyIdx('装备者对其造成的伤害提高[dmg]%，装备者使其防御力降低[ignore]%', { dmg: 1, ignore: 2 })
+      keyIdx('装备者对其造成的伤害提高[dmg]%，装备者使其防御力降低[enemyDef]%', { dmg: 1, enemyDef: 2 })
     ]
   }
 }


### PR DESCRIPTION
风堇在满命条件下，暴伤权重从 75 提升至 100。