### PR TITLE
feat: 调整瓦雷莎、兹白、杜林（辅助）的圣遗物评分规则

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -99,7 +99,7 @@ export const usefulAttr = {
   蓝砚: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 30, dmg: 80, phy: 0, recharge: 75, heal: 0 },
   梦见月瑞希: { hp: 0, atk: 30, def: 0, cpct: 30, cdmg: 30, mastery: 100, dmg: 80, phy: 0, recharge: 45, heal: 95 },
   伊安珊: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 100, heal: 0 },
-  瓦雷莎: { hp: 0, atk: 90, def: 0, cpct: 100, cdmg: 100, mastery: 30, dmg: 100, phy: 0, recharge: 40, heal: 0 },
+  瓦雷莎: { hp: 0, atk: 90, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 40, heal: 0 },
   爱可菲: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 99, phy: 0, recharge: 75, heal: 95 },
   伊法: { hp: 0, atk: 75, def: 0, cpct: 50, cdmg: 50, mastery: 100, dmg: 80, phy: 0, recharge: 35, heal: 100 },
   丝柯克: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 0, heal: 0 },
@@ -112,7 +112,7 @@ export const usefulAttr = {
   杜林: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 20, heal: 0 },
   雅珂达: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 80, phy: 0, recharge: 100, heal: 100 },
   哥伦比娅: { hp: 100, atk: 0, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 0, phy: 0, recharge: 100, heal: 0 },
-  兹白: { hp: 0, atk: 0, def: 100, cpct: 100, cdmg: 100, mastery: 70, dmg: 0, phy: 0, recharge: 40, heal: 0 },
+  兹白: { hp: 0, atk: 0, def: 100, cpct: 100, cdmg: 100, mastery: 60, dmg: 0, phy: 0, recharge: 40, heal: 0 },
   叶洛亚: { hp: 0, atk: 0, def: 50, cpct: 50, cdmg: 50, mastery: 100, dmg: 80, phy: 0, recharge: 100, heal: 0 },
   法尔伽: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 99, phy: 0, recharge: 30, heal: 0 }
 }

--- a/resources/meta-gs/character/兹白/artis.js
+++ b/resources/meta-gs/character/兹白/artis.js
@@ -1,0 +1,14 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({rule, def, weapon}) {
+  let title = []
+  let particularAttr = {...usefulAttr['兹白']}
+  if (weapon.name === '息燧之笛') {
+    title.push('息燧')
+    particularAttr.def = 75
+  }
+  if (title.length > 0) {
+    return rule(`兹白-${title.join('')}`, particularAttr)
+  }
+  return def(usefulAttr['兹白'])
+}

--- a/resources/meta-gs/character/杜林/artis.js
+++ b/resources/meta-gs/character/杜林/artis.js
@@ -6,6 +6,8 @@ export default function ({cons, rule, def, artis}) {
   if (cons > 0 && artis.artis['4'].main && artis.artis['4'].main.key === 'atk') {
     title.push('辅助')
     particularAttr.atk = 100
+    particularAttr.mastery = 30
+    particularAttr.dmg = 80
   }
   if (title.length > 0) {
     return rule(`杜林-${title.join('')}`, particularAttr)


### PR DESCRIPTION
瓦雷莎的精通权重，从 30 降低至 0。
兹白的精通权重，从 70 降低至 60（另外，兹白装备息燧之笛时，防御权重从 100 降低至 75）。 
杜林走辅助路线时（装备攻击杯时），精通和火伤的权重降低。