### PR TITLE
feat: 调整少女、娜维娅的圣遗物评分权重

### DIFF
--- a/resources/meta-gs/character/哥伦比娅/artis.js
+++ b/resources/meta-gs/character/哥伦比娅/artis.js
@@ -1,0 +1,20 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({cons, weapon, rule, def}) {
+  let title = []
+  let particularAttr = {...usefulAttr['哥伦比娅']}
+  let recharge = particularAttr.recharge
+  if (weapon.name === '帷间夜曲') {
+    title.push('专武')
+    recharge -= 20
+  }
+  if (cons >= 4) {
+    title.push('高命')
+    recharge -= 20
+  }
+  if (title.length > 0) {
+    particularAttr.recharge = recharge
+    return rule(`哥伦比娅-${title.join('')}`, particularAttr)
+  }
+  return def(usefulAttr['哥伦比娅'])
+}

--- a/resources/meta-gs/character/娜维娅/artis.js
+++ b/resources/meta-gs/character/娜维娅/artis.js
@@ -1,0 +1,16 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({cons, rule, def}) {
+  let title = []
+  let particularAttr = {...usefulAttr['娜维娅']}
+  let recharge = particularAttr.recharge
+  if (cons >= 1) {
+    title.push('高命')
+    recharge -= 10
+  }
+  if (title.length > 0) {
+    particularAttr.recharge = recharge
+    return rule(`娜维娅-${title.join('')}`, particularAttr)
+  }
+  return def(usefulAttr['娜维娅'])
+}

--- a/resources/meta-gs/character/菲林斯/artis.js
+++ b/resources/meta-gs/character/菲林斯/artis.js
@@ -1,6 +1,6 @@
 import {usefulAttr} from "../../artifact/artis-mark.js"
 
-export default function ({cons, weapon, rule, def}) {
+export default function ({weapon, rule, def}) {
   let title = []
   let particularAttr = {...usefulAttr['菲林斯']}
   let recharge = particularAttr.recharge


### PR DESCRIPTION
少女有专武时，充能权重 -20,；4名以上时，充能权重 -20.
娜维娅1命以上时，充能权重 -10.