### PR TITLE
fix(meta-sr): 调整计算文件中已知的可能的错误语法, 使得面板能够正常展示

### DIFF
--- a/resources/meta-sr/artifact/artis-mark.js
+++ b/resources/meta-sr/artifact/artis-mark.js
@@ -3,6 +3,10 @@
  * 如character/${name}/artis.js下有角色自定义规则优先使用自定义
  */
 export const usefulAttr = {
+  '银狼LV.999': { hp: 30, atk: 0, def: 30, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 0 },
+  不死途: { hp: 0, atk: 100, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 0, effPct: 0, effDef: 0, dmg: 100 },
+  火花: { hp: 0, atk: 75, def: 0, speed: 75, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 75, effPct: 0, effDef: 30, dmg: 0 },
+  爻光: { hp: 30, atk: 0, def: 30, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 30, dmg: 0 },
   大丽花: { hp: 20, atk: 100, def: 20, speed: 100, cpct: 0, cdmg: 0, stance: 100, heal: 0, recharge: 30, effPct: 0, effDef: 30, dmg: 0 },
   昔涟: { hp: 100, atk: 0, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 50, effPct: 0, effDef: 0, dmg: 100 },
   '丹恒•腾荒': { hp: 0, atk: 100, def: 0, speed: 100, cpct: 50, cdmg: 50, stance: 0, heal: 0, recharge: 100, effPct: 0, effDef: 0, dmg: 50 },
@@ -92,5 +96,7 @@ export const usefulAttr = {
   '穹·毁灭': { hp: 0, atk: 75, def: 0, speed: 75, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 50, effPct: 0, effDef: 0, dmg: 100 },
   '星·毁灭': { hp: 0, atk: 75, def: 0, speed: 75, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 50, effPct: 0, effDef: 0, dmg: 100 },
   '穹·记忆': { hp: 0, atk: 100, def: 0, speed: 100, cpct: 0, cdmg: 100, stance: 0, heal: 0, recharge: 50, effPct: 0, effDef: 0, dmg: 0 },
-  '星·记忆': { hp: 0, atk: 100, def: 0, speed: 100, cpct: 0, cdmg: 100, stance: 0, heal: 0, recharge: 50, effPct: 0, effDef: 0, dmg: 0 }
+  '星·记忆': { hp: 0, atk: 100, def: 0, speed: 100, cpct: 0, cdmg: 100, stance: 0, heal: 0, recharge: 50, effPct: 0, effDef: 0, dmg: 0 },
+  '穹·欢愉': { hp: 0, atk: 100, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 75, effPct: 0, effDef: 0, dmg: 0 },
+  '星·欢愉': { hp: 0, atk: 100, def: 0, speed: 100, cpct: 100, cdmg: 100, stance: 0, heal: 0, recharge: 75, effPct: 0, effDef: 0, dmg: 0 },
 }

--- a/resources/meta-sr/character/星·欢愉/calc.js
+++ b/resources/meta-sr/character/星·欢愉/calc.js
@@ -4,19 +4,47 @@ export const details = [{
 }, {
   title: '战技对单80好活伤害',
   params: { punchline: 80 },
-  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg,
+      avg: a.avg + b.avg,
+    }
+  }
 }, {
   title: '战技对三80好活伤害',
   params: { punchline: 80 },
-  dmg: ({ talent }, dmg) => (dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')) * 3
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg * 3,
+      avg: a.avg + b.avg * 3,
+    }
+  }
 }, {
   title: '战技对单900好活伤害',
   params: { punchline: 900 },
-  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg,
+      avg: a.avg + b.avg,
+    }
+  }
 }, {
   title: '战技对三900好活伤害',
   params: { punchline: 900 },
-  dmg: ({ talent }, dmg) => (dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')) * 3
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg * 3,
+      avg: a.avg + b.avg * 3,
+    }
+  }
 }, {
   title: '50笑点欢愉技伤害',
   params: { punchline: 50 },

--- a/resources/meta-sr/character/穹·欢愉/calc.js
+++ b/resources/meta-sr/character/穹·欢愉/calc.js
@@ -4,19 +4,47 @@ export const details = [{
 }, {
   title: '战技对单80好活伤害',
   params: { punchline: 80 },
-  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg,
+      avg: a.avg + b.avg,
+    }
+  }
 }, {
   title: '战技对三80好活伤害',
   params: { punchline: 80 },
-  dmg: ({ talent }, dmg) => (dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')) * 3
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg * 3,
+      avg: a.avg + b.avg * 3,
+    }
+  }
 }, {
   title: '战技对单900好活伤害',
   params: { punchline: 900 },
-  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg,
+      avg: a.avg + b.avg,
+    }
+  }
 }, {
   title: '战技对三900好活伤害',
   params: { punchline: 900 },
-  dmg: ({ talent }, dmg) => (dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['技能伤害'], 'xe', 'elation')) * 3
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg * 3,
+      avg: a.avg + b.avg * 3,
+    }
+  }
 }, {
   title: '50笑点欢愉技伤害',
   params: { punchline: 50 },

--- a/resources/meta-sr/character/银狼LV.999/calc.js
+++ b/resources/meta-sr/character/银狼LV.999/calc.js
@@ -1,11 +1,25 @@
 export const details = [{
   title: '普攻对单60好活伤害',
   params: { punchline: 60 },
-  dmg: ({ talent }, dmg) => dmg(talent.a['技能伤害'], 'a') + dmg(talent.t['普攻战技技能伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.a['技能伤害'], 'a')
+    let b = dmg(talent.t['普攻战技技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg,
+      avg: a.avg + b.avg,
+    }
+  }
 }, {
   title: '战技对单60好活伤害',
   params: { punchline: 60 },
-  dmg: ({ talent }, dmg) => dmg(talent.e['技能伤害'], 'e') + dmg(talent.t['普攻战技技能伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.e['技能伤害'], 'e')
+    let b = dmg(talent.t['普攻战技技能伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg,
+      avg: a.avg + b.avg,
+    }
+  }
 }, {
   title: '100好活头号补给盲盒伤害',
   params: { punchline: 100 },
@@ -13,23 +27,43 @@ export const details = [{
 }, {
   title: '100好活超超超大剑',
   params: { punchline: 100 },
-  dmg: ({ talent }, dmg) => dmg(talent.q['盲盒伤害'], 'xe', 'elation') * 0.2
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.a['技能伤害'], 'a')
+    return {
+      dmg: a.dmg * 0.2,
+      avg: a.avg * 0.2,
+    }
+  }
 }, {
   title: '100好活强化普攻',
   params: { punchline: 100, a2: true },
-  dmg: ({ talent }, dmg) => dmg(talent.a2['弹射伤害'], 'xe', 'elation') + dmg(talent.a2['均分伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.a2['弹射伤害'], 'xe', 'elation')
+    let b = dmg(talent.a2['均分伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg + b.dmg,
+      avg: a.avg + b.avg,
+    }
+  }
 }, {
-  title: '100好活强化普攻加3次超超超大剑',
+  title: '百活强普三大剑',
   params: { punchline: 100, a2: true },
-  dmg: ({ talent }, dmg) => dmg(talent.a2['弹射伤害'], 'xe', 'elation') * 1.2 + dmg(talent.a2['均分伤害'], 'xe', 'elation')
+  dmg: ({ talent }, dmg) => {
+    let a = dmg(talent.a2['弹射伤害'], 'xe', 'elation')
+    let b = dmg(talent.a2['均分伤害'], 'xe', 'elation')
+    return {
+      dmg: a.dmg * 1.2 + b.dmg,
+      avg: a.avg * 1.2 + b.avg,
+    }
+  }
 }, {
   title: '60笑点欢愉技伤害',
   params: { punchline: 60, xe: true, q: true },
-  dmg: ({ talent }, dmg) => dmg(talent.xe['弹射伤害'] * 6, 'xe', 'elation')
+  dmg: ({ talent }, dmg) => dmg(talent.xe2['弹射伤害'] * 6, 'xe', 'elation')
 }]
 
-export const defDmgIdx = 1
-export const mainAttr = 'atk,cpct,cdmg'
+export const defDmgIdx = 5
+export const mainAttr = 'speed,cpct,cdmg,atk'
 
 export const buffs = [{
   title: '行迹-假结局速通攻略：速度大于等于160时，使自身欢愉度提高50%，之后每超过1点速度使自身欢愉度提高2%',


### PR DESCRIPTION
> 变动范围: 只修改使得能够显示数据, 并未完善角色计算逻辑

1. 搜了一下没找到重载符类似的概念, 全拆开来拼了
2. 金狼有一项的计算写错了键值
3. 补充了遗器评分. (非强度党, 有所偏颇, 这一块应该其他人来补充or更新)
4. (题外话)最近发生了什么? 拉取下来后我大惊失色