### PR TITLE
尼可&布伦妮一些修改

### DIFF
--- a/resources/character/profile-stat.html
+++ b/resources/character/profile-stat.html
@@ -83,7 +83,7 @@
         </div>
         {{if !isSr}}
         <div class="td td-fetter">
-          <span class="fetter fetter{{['空','荧','旅行者'].includes(avatar.name)?10:avatar.fetter}}"></span>
+          <span class="fetter fetter{{['空','荧','旅行者,'奇偶·男性','奇偶·女性'].includes(avatar.name)?10:avatar.fetter}}"></span>
         </div>
         {{/if}}
         {{set talentLvMap = [0,1,1,1,2,2,3,3,3,4,5] }}

--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -116,6 +116,6 @@ export const usefulAttr = {
   叶洛亚: { hp: 0, atk: 0, def: 50, cpct: 50, cdmg: 50, mastery: 100, dmg: 80, phy: 0, recharge: 100, heal: 0 },
   法尔伽: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 99, phy: 0, recharge: 30, heal: 0 },
   莉奈娅: { hp: 0, atk: 0, def: 100, cpct: 100, cdmg: 100, mastery: 50, dmg: 0, phy: 0, recharge: 50, heal: 99 },
-  尼可: { hp: 0, atk: 100, def: 0, cpct: 50, cdmg: 50, mastery: 0, dmg: 0, phy: 0, recharge: 30, heal: 0 },
+  尼可: { hp: 0, atk: 100, def: 0, cpct: 0, cdmg: 0, mastery: 0, dmg: 0, phy: 0, recharge: 50, heal: 0 },
   布伦妮: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 99, phy: 0, recharge: 100, heal: 0 }
 }

--- a/resources/meta-gs/character/尼可/calc.js
+++ b/resources/meta-gs/character/尼可/calc.js
@@ -25,7 +25,7 @@ export const details = [{
 }]
 
 export const defParams = { "虚己之赐": true, "圣祝之引": true, Hexenzirkel: true }
-export const defDmgIdx = 2
+export const defDmgIdx = 1
 export const mainAttr = "atk,cpct,cdmg,dmg"
 
 export const buffs = [{

--- a/resources/meta-gs/character/布伦妮/calc.js
+++ b/resources/meta-gs/character/布伦妮/calc.js
@@ -2,16 +2,16 @@ export const details = [{
   title: "「狩灾誓锤」提升队友伤害",
   dmg: ({ calc, attr }) => {
     return {
-      avg: Math.round(Math.min((calc(attr.atk) - 2000) * 0.025, 50) * 100) / 100 + "%",
+      avg: Math.round(Math.min(Math.max((calc(attr.atk) - 2000) * 0.025, 0), 50) * 100) / 100 + "%",
       type: "text"
     }
   }
 }, {
   title: "E一段伤害",
-  dmg: ({ talent }, dmg) => dmg(talent.e["技能一段伤害"], "e")
+  dmg: ({ talent }, dmg) => dmg(talent.e["叮铃铃·猎魔之音伤害"], "e")
 }, {
   title: "E二段伤害",
-  dmg: ({ talent }, dmg) => dmg(talent.e["技能二段伤害"], "e")
+  dmg: ({ talent }, dmg) => dmg(talent.e["咚锵锵·裁魔之惩伤害"], "e")
 }, {
   title: "Q释放伤害",
   dmg: ({ talent }, dmg) => dmg(talent.q["技能伤害"], "q")


### PR DESCRIPTION
尼可：评分改为只需要攻击和充能，双爆没啥用，排序改为盾量，攻击力提升有上限容易触顶，到时候群排名一堆攻击力加成一样的，改成盾量攻击力高盾量也自然高
布伦妮：现有逻辑增加一层，确保当攻击力小于2000时计算结果不为负数。