### PR TITLE
feat: 新增玛薇卡圣遗物评分规则

### DIFF
--- a/resources/meta-gs/character/玛薇卡/artis.js
+++ b/resources/meta-gs/character/玛薇卡/artis.js
@@ -1,0 +1,15 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({attr, rule, def}) {
+  let title = []
+  let particularAttr = {...usefulAttr['玛薇卡']}
+  if (attr.mastery < 50) {
+    title.push('纯火/超载')
+    particularAttr.atk = 85
+    particularAttr.mastery = 0
+  }
+  if (title.length > 0) {
+    return rule(`玛薇卡-${title.join('')}`, particularAttr)
+  }
+  return def(usefulAttr['玛薇卡'])
+}


### PR DESCRIPTION
-玛薇卡精通低于50时，视为纯火或超载，攻击权重从 75 提高至 85，精通权重从 85 降低至 0。