### PR TITLE
feat&fix: 圣遗物评分兼容主词条候选权重全为0的位置，新增莫娜、芙宁娜、爱可菲圣遗物评分规则

### DIFF
--- a/models/artis/ArtisMark.js
+++ b/models/artis/ArtisMark.js
@@ -122,7 +122,8 @@ let ArtisMark = {
             mainKey = 'dmg'
           }
         }
-        fixPct = Math.max(0, Math.min(1, (attrs[mainKey]?.weight || 0) / (posMaxMark['m' + idx])))
+        let mMax = posMaxMark['m' + idx]
+        fixPct = mMax > 0 ? Math.max(0, Math.min(1, (attrs[mainKey]?.weight || 0) / mMax)) : 1
         if (game === 'gs') {
           if (['atk', 'hp', 'def'].includes(mainKey) && attrs[mainKey]?.weight >= 75) {
             fixPct = 1
@@ -135,7 +136,8 @@ let ArtisMark = {
     lodash.forEach(sAttr, (ds) => {
       ret += (attrs[ds.key]?.mark || 0) * (ds.value || 0)
     })
-    return ret * (1 + fixPct) / 2 / posMaxMark[idx] * 66
+    let pMax = posMaxMark[idx]
+    return pMax > 0 ? ret * (1 + fixPct) / 2 / pMax * 66 : 0
   },
 
   // 获取位置最高分
@@ -151,9 +153,14 @@ let ArtisMark = {
       } else if (idx === 2) {
         mAttr = 'atkPlus'
       } else if (idx >= 3) {
-        mAttr = ArtisMark.getMaxAttr(attrs, mainAttr[idx])[0]
-        mMark = attrs[mAttr].fixWeight
-        totalMark += attrs[mAttr].fixWeight * 2
+        let mainCandidates = ArtisMark.getMaxAttr(attrs, mainAttr[idx])
+        if (mainCandidates.length > 0) {
+          mAttr = mainCandidates[0]
+          mMark = attrs[mAttr].fixWeight
+          totalMark += mMark * 2
+        } else {
+          mAttr = mainAttr[idx][0]
+        }
       }
 
       let sAttr = ArtisMark.getMaxAttr(attrs, subAttr, 4, mAttr)

--- a/resources/meta-gs/character/爱可菲/artis.js
+++ b/resources/meta-gs/character/爱可菲/artis.js
@@ -1,0 +1,28 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({ attr, weapon, rule, def }) {
+  let title = []
+  let particularAttr = {...usefulAttr['爱可菲']}
+  if (weapon.name === '西风长枪' && attr.recharge >= 230) {
+    title = [] 
+    title.push('西风纯辅')
+    particularAttr.atk = 0
+    particularAttr.cpct = 100
+    particularAttr.cdmg = 0
+    particularAttr.recharge = 100
+    particularAttr.dmg = 0
+  }
+  if (weapon.name === '香韵奏者' && attr.recharge >= 230) {
+    title = [] 
+    title.push('餐叉纯辅')
+    particularAttr.atk = 0
+    particularAttr.cpct = 0
+    particularAttr.cdmg = 0
+    particularAttr.recharge = 100
+    particularAttr.dmg = 0
+  }
+  if (title.length > 0) {
+    return rule(`爱可菲-${title.join('')}`, particularAttr)
+  }
+  return def(usefulAttr['爱可菲'])
+}

--- a/resources/meta-gs/character/芙宁娜/artis.js
+++ b/resources/meta-gs/character/芙宁娜/artis.js
@@ -1,17 +1,47 @@
 import {usefulAttr} from "../../artifact/artis-mark.js"
 
-export default function ({cons, weapon, rule, def}) {
-    let title = []
-    let particularAttr = {...usefulAttr['芙宁娜']}
-    if (cons >= 4) {
-        title.push('高命')
-        particularAttr.recharge = 60
-        if (cons == 6) {
-            particularAttr.mastery = 45
-        }
+export default function ({ attr, cons, weapon, rule, def }) {
+  let title = []
+  let particularAttr = {...usefulAttr['芙宁娜']}
+  if (cons >= 4) {
+    title.push('高命')
+    particularAttr.recharge = 60
+    if (cons == 6) {
+      particularAttr.mastery = 45
     }
-    if (title.length > 0) {
-        return rule(`芙宁娜-${title.join('')}`, particularAttr)
-    }
-    return def(usefulAttr['芙宁娜'])
+  }
+  if (weapon.name === '西风剑' && attr.recharge >= 250) {
+    title = [] 
+    title.push('西风纯辅')
+    particularAttr.hp = 0
+    particularAttr.mastery = 0
+    particularAttr.cpct = 100
+    particularAttr.cdmg = 0
+    particularAttr.recharge = 100
+    particularAttr.dmg = 0
+  }
+  if (weapon.name === '苍古自由之誓' && attr.recharge >= 250) {
+    title = [] 
+    title.push('苍古纯辅')
+    particularAttr.hp = 0
+    particularAttr.mastery = 0
+    particularAttr.cpct = 0
+    particularAttr.cdmg = 0
+    particularAttr.recharge = 100
+    particularAttr.dmg = 0
+  }
+  if (weapon.name === '圣显之钥' && attr.recharge >= 250) {
+    title = [] 
+    title.push('板砖纯辅')
+    particularAttr.hp = 100
+    particularAttr.mastery = 0
+    particularAttr.cpct = 0
+    particularAttr.cdmg = 0
+    particularAttr.recharge = 100
+    particularAttr.dmg = 0
+  }
+  if (title.length > 0) {
+    return rule(`芙宁娜-${title.join('')}`, particularAttr)
+  }
+  return def(usefulAttr['芙宁娜'])
 }

--- a/resources/meta-gs/character/莫娜/artis.js
+++ b/resources/meta-gs/character/莫娜/artis.js
@@ -1,0 +1,28 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({ rule, def, weapon }) {
+  let title = []
+  let particularAttr = {...usefulAttr['莫娜']}
+  if (weapon.name === '西风秘典') {
+    title.push('西风')
+    particularAttr.atk = 0
+    particularAttr.mastery = 0
+    particularAttr.cpct = 100
+    particularAttr.cdmg = 0
+    particularAttr.recharge = 100
+    particularAttr.dmg = 0
+  }
+  if (weapon.name === '讨龙英杰谭') {
+    title.push('讨龙')
+    particularAttr.atk = 0
+    particularAttr.mastery = 0
+    particularAttr.cpct = 0
+    particularAttr.cdmg = 0
+    particularAttr.recharge = 100
+    particularAttr.dmg = 0
+  }
+  if (title.length > 0) {
+    return rule(`莫娜-${title.join('')}`, particularAttr)
+  }
+  return def(usefulAttr['莫娜'])
+}


### PR DESCRIPTION
底层修复（7a7d895）
  此前角色自定义权重将非核心属性设为0后，getMaxAttr 返回空数组导致 TypeError。本改动使空候选安全降级。以讨龙莫娜为例，当前版本充能词条为唯一有效词条，但其他词条权重设为0，会使 getMaxAttr 返回空数组导致 TypeError ，修复后这些属性可直接设为0，评分只按充能词条计算，不再混入无关属性的噪声。
  - models/artis/ArtisMark.js
    - getMaxMark: getMaxAttr返回空时不再崩溃，回退取原始候选第一项，主词条贡献为0
    - getMark fixPct: 理论最佳主词条分为0时fixPct=1，不因主词条选择扣分
    - getMark 最终除法: 理论满分为0时返回0，兜底除零
 
新增圣遗物评分规则（e2d5524、dd407a5）
  在此修复基础（7a7d895）上，新增三个角色的纯辅评分规则——充能偏高时且携带辅助武器时视为纯辅流派，提高充能权重、无关属性降为 0
  - resources/meta-gs/character/莫娜/artis.js
  - resources/meta-gs/character/芙宁娜/artis.js
  - resources/meta-gs/character/爱可菲/artis.js

现在危战冷启动环境，辅助角色普遍放弃伤害追求高充能以便更快启动，在面板充能偏高时且携带辅助武器时往往舍弃了伤害词条，这种条件下保留伤害词条无法客观反映角色真正的练度（高充能圣遗物也不好刷），视为纯辅只保留充能和部分所需属性更为客观