### PR TITLE
fix: 修正木偶伤害计算bug；补充八重神子伤害计算

### DIFF
--- a/models/dmg/DmgCalc.js
+++ b/models/dmg/DmgCalc.js
@@ -230,8 +230,8 @@ let DmgCalc = {
         } else if (ele === 'lunarCrystallize') {
           eleNum = dmgBase ? 1.6 : eleNum
         } else if (ele === 'stellarConduct') {
-          // 星超导根据hit数的不同，有 1/1.45/1.9 三档倍率，这里暂时默认为最大值 1.9
-          eleNum = dmgBase ? 1.9 : eleNum
+          // 星超导根据hit数的不同，有 1.45 - 2.0 不等的倍率，这里暂时默认为最大值 2.0
+          eleNum = dmgBase ? 2 : eleNum
         } else {
           eleNum = 1
         }

--- a/resources/meta-gs/character/八重神子/calc.js
+++ b/resources/meta-gs/character/八重神子/calc.js
@@ -4,10 +4,20 @@ export const details = [{
   title: '叄阶杀生樱伤害',
   dmg: ({ talent }, dmg) => dmg(talent.e['杀生樱伤害·叁阶'], 'e')
 }, {
+  check: ({ cons }) => cons < 2,
+  dmgKey: 'e',
+  title: '强化叄阶杀生樱伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['杀生樱伤害·叁阶'] + 80, 'e')
+}, {
   check: ({ cons }) => cons >= 2,
   dmgKey: 'e',
   title: '肆阶杀生樱伤害',
   dmg: ({ talent }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'], 'e')
+}, {
+  check: ({ cons }) => cons >= 2,
+  dmgKey: 'e',
+  title: '强化肆阶杀生樱伤害',
+  dmg: ({ talent }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'] + 80, 'e')
 }, {
   check: ({ cons }) => cons < 2,
   title: '叄阶杀生樱激化伤害',
@@ -17,10 +27,23 @@ export const details = [{
   title: '肆阶杀生樱激化伤害',
   dmg: ({ talent }, dmg) => dmg(talent.e['杀生樱伤害·肆阶'], 'e', 'aggravate')
 }, {
+  title: '【辉映·星超导】强化落雷命中后额外星超导伤害',
+  params: { Stellar: true },
+  dmg: ({ attr, calc, talent }, { basic }) => basic(calc(attr.atk) * 200 / 100, '', 'stellarConduct')
+}, {
+  title: 'E施放后额外雷击伤害',
+  dmg: ({ talent }, dmg) => dmg(40, '')
+}, {
+  title: '【辉映·星超导】E施放后额外星超导伤害',
+  params: { Stellar: true },
+  dmg: ({ attr, calc, talent }, { basic }) => basic(calc(attr.atk) * 50 / 100, '', 'stellarConduct')
+}, {
   title: '四段Q总伤害',
+  params: { Q: true },
   dmg: ({ talent }, dmg) => dmg(talent.q['技能伤害'] + talent.q['天狐霆雷伤害'] * 3, 'q')
 }, {
   title: '四段Q总激化伤害',
+  params: { Q: true },
   dmg: ({ talent }, dmg) => {
     let q1j = dmg(talent.q['技能伤害'], 'q', 'aggravate')
     let q2j = dmg(talent.q['天狐霆雷伤害'], 'q', 'aggravate')
@@ -41,10 +64,30 @@ export const buffs = [{
     eDmg: ({ attr, calc }) => calc(attr.mastery) * 0.15
   }
 }, {
-  check: ({ cons }) => cons >= 4,
+  cons: 1,
+  title: '1命效果：触发超导/星超导反应或造成星超导反应伤害后，获得[dmg]%雷元素伤害加成和星超导伤害加成',
+  data: {
+    dmg: 50,
+    stellarConduct: 50,
+  }
+}, {
+  cons: 2,
+  title: '2命效果：肆阶杀生樱在场时，元素精通提高[mastery]',
+  data: {
+    mastery: 200
+  }
+}, {
+  cons: 4,
   title: '4命效果：杀生樱命中敌人后提高雷伤[dmg]%',
   data: {
     dmg: 20
+  }
+}, {
+  check: ({ params }) => params.Q === true,
+  cons: 4,
+  title: '4命效果：元素爆发伤害提升[dmg]%',
+  data: {
+    dmg: 100
   }
 }, {
   cons: 6,
@@ -52,4 +95,11 @@ export const buffs = [{
   data: {
     eDef: 60
   }
-}, 'aggravate']
+}, {
+  check: ({ params }) => params.Stellar === true,
+  cons: 6,
+  title: '6命效果：星超导反应伤害的暴击伤害提升[cdmg]%',
+  data: {
+    cdmg: 200
+  }
+}]

--- a/resources/meta-gs/character/桑多涅/calc.js
+++ b/resources/meta-gs/character/桑多涅/calc.js
@@ -5,7 +5,7 @@ export const details = [
   },
   {
     title: '重击冷凝射线星超导伤害',
-    params: { Stellar: true },
+    params: { Stellar: true, a2: true },
     dmg: ({ attr, calc, talent }, { basic }) => basic(calc(attr.atk) * talent.a['重击冷凝射线星超导伤害'] / 100, '', 'stellarConduct')
   },
   {
@@ -45,6 +45,12 @@ export const mainAttr = 'atk,cpct,cdmg,mastery'
 
 export const buffs = [
   {
+    title: '双冰共鸣：攻击冰元素附着或冻结状态下的敌人时，暴击率提高[cpct]%',
+    data: {
+      cpct: 15
+    }
+  },
+  {
     check: ({ params }) => params.Stellar === true,
     title: '桑多涅天赋：基于桑多涅的攻击力，对队伍中角色造成的星超导反应提升[fypct]%的基础伤害',
     sort: 9,
@@ -67,6 +73,7 @@ export const buffs = [
     }
   },
   {
+    check: ({ params }) => params.a2 === true,
     title: '桑多涅2命：【辉映·星超导】3层状态下，重击发射的冷凝射线的暴击伤害提升[cdmg]%',
     cons: 2,
     data: {


### PR DESCRIPTION
1、修正木偶2命作用于全部伤害计算的bug（应为仅重击星超导伤害生效）
2、修正星超导伤害倍率有误的bug（满层应为2.0）
3、在木偶伤害计算中，添加双冰共鸣的buff