### PR TITLE
fix:角色图鉴文本对齐修改

### DIFF
--- a/resources/wiki/character-wiki.css
+++ b/resources/wiki/character-wiki.css
@@ -56,7 +56,7 @@ body {
 .detail ul.char-attr li span {
   color: #fff;
   text-align: right;
-  width: 130px;
+  width: 140px;
 }
 .material-list {
   display: flex;


### PR DESCRIPTION
某些角色地区归属文本过长会往下一行显示
修改前：
<img width="557" height="460" alt="QQ20260720-191650" src="https://github.com/user-attachments/assets/4a2b75be-d303-4ea5-beac-227fa5ef67b0" />
修改后：
<img width="548" height="454" alt="QQ20260720-191956" src="https://github.com/user-attachments/assets/2c07722a-97bd-4e84-bb85-361b0f2a27e8" />
