### PR TITLE
feat: 新增&调整八重神子、莱欧斯利、赛诺、爱可菲、温迪的圣遗物权重规则

### DIFF
--- a/resources/meta-gs/artifact/artis-mark.js
+++ b/resources/meta-gs/artifact/artis-mark.js
@@ -19,7 +19,7 @@ export const usefulAttr = {
   神里绫华: { hp: 0, atk: 85, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 45, heal: 0 },
   香菱: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 75, heal: 0 },
   胡桃: { hp: 80, atk: 50, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 0, heal: 0 },
-  温迪: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 45, heal: 0 },
+  温迪: { hp: 0, atk: 100, def: 0, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 45, heal: 0 },
   珊瑚宫心海: { hp: 100, atk: 50, def: 0, cpct: 0, cdmg: 0, mastery: 75, dmg: 100, phy: 0, recharge: 55, heal: 100 },
   莫娜: { hp: 0, atk: 75, def: 0, cpct: 100, cdmg: 100, mastery: 75, dmg: 100, phy: 0, recharge: 75, heal: 0 },
   阿贝多: { hp: 0, atk: 0, def: 75, cpct: 100, cdmg: 100, mastery: 0, dmg: 100, phy: 0, recharge: 0, heal: 0 },

--- a/resources/meta-gs/character/八重神子/artis.js
+++ b/resources/meta-gs/character/八重神子/artis.js
@@ -1,0 +1,15 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({artis, rule, def}) {
+    let title = []
+    let particularAttr = {...usefulAttr['八重神子']}
+    if (artis.names.includes('影中沉凝的幻灭')) {
+        title.push('星超导')
+        particularAttr.mastery = 100
+        particularAttr.dmg = 0
+    }
+    if (title.length > 0) {
+        return rule(`八重神子-${title.join('')}`, particularAttr)
+    }
+    return def(usefulAttr['八重神子'])
+}

--- a/resources/meta-gs/character/爱可菲/artis.js
+++ b/resources/meta-gs/character/爱可菲/artis.js
@@ -1,0 +1,22 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({attr, cons, def, rule}) {
+    let title = []
+    let particularAttr = {...usefulAttr['爱可菲']}
+    if (attr.recharge >= 200) {
+        title.push('纯辅')
+        particularAttr.atk = 75
+        particularAttr.cpct = 0
+        particularAttr.cdmg = 0
+        particularAttr.dmg = 0
+        particularAttr.recharge = 100
+        if (cons > 1) {
+            title.push('|高命')
+            particularAttr.atk = 100
+        }
+    }
+    if (title.length > 0) {
+        return rule(`爱可菲-${title.join('')}`, particularAttr)
+    }
+    return def(usefulAttr['爱可菲'])
+}

--- a/resources/meta-gs/character/莱欧斯利/artis.js
+++ b/resources/meta-gs/character/莱欧斯利/artis.js
@@ -1,0 +1,15 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({artis, rule, def}) {
+    let title = []
+    let particularAttr = {...usefulAttr['莱欧斯利']}
+    if (artis.names.includes('影中沉凝的幻灭')) {
+        title.push('星超导')
+        particularAttr.mastery = 100
+        particularAttr.dmg = 0
+    }
+    if (title.length > 0) {
+        return rule(`莱欧斯利-${title.join('')}`, particularAttr)
+    }
+    return def(usefulAttr['莱欧斯利'])
+}

--- a/resources/meta-gs/character/赛诺/artis.js
+++ b/resources/meta-gs/character/赛诺/artis.js
@@ -1,0 +1,20 @@
+import {usefulAttr} from "../../artifact/artis-mark.js"
+
+export default function ({artis, weapon, def, rule}) {
+    let title = []
+    let particularAttr = {...usefulAttr['赛诺']}
+    if (artis.names.includes('影中沉凝的幻灭')) {
+        title.push('星超导')
+        particularAttr.mastery = 100
+        particularAttr.dmg = 0
+        particularAttr.recharge = 40
+        if (weapon.name === '赤沙之杖') {
+            title.push('|专武')
+            particularAttr.atk = 50
+        }
+    }
+    if (title.length > 0) {
+        return rule(`赛诺-${title.join('')}`, particularAttr)
+    }
+    return def(usefulAttr['赛诺'])
+}


### PR DESCRIPTION
新增八重神子、莱欧斯利、赛诺在星超导条件下的圣遗物权重规则（当圣遗物穿戴4件以上幻灭套时）；
新增爱可菲“纯辅”规则（当爱可菲充能不小于200时）；
提高温迪的攻击权重，从 75 提升至 100。