### PR TITLE
fix: 处理面板列表图片生成失败

### DIFF
--- a/apps/profile/ProfileList.js
+++ b/apps/profile/ProfileList.js
@@ -151,7 +151,7 @@ const ProfileList = {
 
     player.save()
     // 渲染图像
-    return e.reply([await Common.render('character/profile-list', {
+    const img = await Common.render('character/profile-list', {
       save_id: uid,
       uid,
       chars,
@@ -163,7 +163,11 @@ const ProfileList = {
       allowRank: rank && rank.allowRank,
       rankCfg,
       elem: player.isGs ? 'hydro' : 'sr'
-    }, { e, scale: 1.6, retType: 'base64' }), new Button(e).profileList(uid, newChar)])
+    }, { e, scale: 1.6, retType: 'base64' })
+    if (!img) {
+      return e.reply('面板图片生成失败，请稍后重试...')
+    }
+    return e.reply([img, new Button(e).profileList(uid, newChar)])
   },
 
   /**


### PR DESCRIPTION
## 问题

当 `Common.render()` 因 Puppeteer 超时等原因返回 `false` 时，`ProfileList.render()` 仍会将该返回值和角色按钮一起传给 `e.reply()`。部分适配器会因此向用户发送文本 `false`。

## 修改

- 先保存面板列表的图片渲染结果
- 渲染失败时提示用户稍后重试，不再发送无效返回值和角色按钮
- 渲染成功时保持原有回复结构

## 验证

- `node --check apps/profile/ProfileList.js`
- `git diff --check`