### PR TITLE
[Bug fix]修复ck失效时无限递归问题

### DIFF
--- a/models/MysApi.js
+++ b/models/MysApi.js
@@ -2,6 +2,88 @@ import { User } from './index.js'
 import { Version } from '#miao'
 import { Button } from '#miao.models'
 
+const PATCHED_GET_COOKIE = Symbol.for('miao-plugin.mysInfo.getCookie')
+const MAX_COOKIE_SELECTIONS = 50
+
+function getGameKey (game) {
+  if (game && typeof game === 'object') {
+    game = game.game || game.key || (game.isSr ? 'sr' : 'gs')
+  }
+  return ['sr', 'star'].includes(game) ? 'sr' : 'gs'
+}
+
+// Prevent old Yunzai runtimes from recursively selecting the same invalid CK.
+function patchMysInfoGetCookie (runtime) {
+  const MysInfo = runtime?.MysInfo
+  const MysUser = runtime?.MysUser
+  const prototype = MysInfo?.prototype
+  const original = prototype?.getCookie
+
+  if (typeof original !== 'function' || original[PATCHED_GET_COOKIE]) {
+    return false
+  }
+  if (!/this\.getCookie\s*\(/.test(Function.prototype.toString.call(original))) {
+    return false
+  }
+
+  let getCookie
+  if (typeof MysUser?.getByQueryUid !== 'function') {
+    const callDepth = new WeakMap()
+    getCookie = async function (game = 'gs', ...args) {
+      const depth = (callDepth.get(this) || 0) + 1
+      if (depth > MAX_COOKIE_SELECTIONS) {
+        return ''
+      }
+      callDepth.set(this, depth)
+      try {
+        return await original.call(this, getGameKey(game), ...args)
+      } finally {
+        if (depth === 1) {
+          callDepth.delete(this)
+        } else {
+          callDepth.set(this, depth - 1)
+        }
+      }
+    }
+  } else {
+    getCookie = async function (game = 'gs', onlySelfCk = false) {
+      game = getGameKey(game)
+      if (this.ckUser?.ck) {
+        return this.ckUser.ck
+      }
+
+      const attempted = new Set()
+      for (let count = 0; count < MAX_COOKIE_SELECTIONS; count++) {
+        const mysUser = await MysUser.getByQueryUid(this.uid, game, onlySelfCk)
+        if (!mysUser) {
+          break
+        }
+        if (mysUser.ck) {
+          this.ckInfo = mysUser.getCkInfo(game)
+          this.ckUser = mysUser
+          await mysUser.addQueryUid(this.uid, game)
+          return mysUser.ck
+        }
+
+        const ltuid = mysUser.ltuid && String(mysUser.ltuid)
+        if (!ltuid || attempted.has(ltuid)) {
+          break
+        }
+        attempted.add(ltuid)
+        await mysUser.disable(game)
+        if (onlySelfCk) {
+          break
+        }
+      }
+      return ''
+    }
+  }
+
+  Object.defineProperty(getCookie, PATCHED_GET_COOKIE, { value: true })
+  prototype.getCookie = getCookie
+  return true
+}
+
 export default class MysApi {
   constructor(e, uid, mysInfo) {
     this.e = e
@@ -42,6 +124,7 @@ export default class MysApi {
       Version.runtime()
       return false
     }
+    patchMysInfoGetCookie(e.runtime)
     let mys = await e.runtime.getMysInfo(auth)
     if (!mys) {
       return false
@@ -111,13 +194,17 @@ export default class MysApi {
       }
     }
     e._reqCount++
-    let ret = await mys.getData(api, data)
-    if (mysInfo && mysInfo.checkCode) {
-      ret = await mysInfo.checkCode(ret, api, this.mys, data)
-    }
-    e._reqCount--
-    if (e._reqCount === 0) {
-      e.reply = e._original_reply
+    let ret
+    try {
+      ret = await mys.getData(api, data)
+      if (mysInfo && mysInfo.checkCode) {
+        ret = await mysInfo.checkCode(ret, api, this.mys, data)
+      }
+    } finally {
+      e._reqCount--
+      if (e._reqCount === 0) {
+        e.reply = e._original_reply
+      }
     }
     if (!ret) {
       return false


### PR DESCRIPTION
## 问题说明

部分版本 Yunzai 运行时在获取 CK 时采用递归重试逻辑。

当缓存中存在已经失效或缺少 Cookie 的 CK，且禁用操作未能及时清除对应查询记录时，运行时可能持续选回同一个 `ltuid`，日志中会反复出现：

- `标记无效ck`
- `使用已查询ck`

递归过程中会不断创建异步调用和日志对象，最终可能触发：

```text
FATAL ERROR: Ineffective mark-compacts near heap limit
Allocation failed - JavaScript heap out of memory
```


## 修改内容
- 初始化 MysApi 前检查运行时的 getCookie() 实现。
- 仅对仍然使用递归重试的旧版运行时应用兼容处理。
- 将 CK 选择改为有上限的迭代逻辑。
- 记录本次查询已经尝试过的 ltuid，再次选中同一个无效 CK 时立即停止。
- 找到其他有效 CK 时继续正常查询。
- 对未公开 MysUser 的运行时保留递归深度保护，避免无限递归。
- 按 Yunzai 的现有约定规范化 gs、sr 和 star 游戏标识。
- 使用 finally 恢复临时修改的 e.reply 和请求计数，防止请求异常后残留状态。

## 兼容性
- 只在检测到旧版递归 getCookie() 实现时生效。
- 新版非递归运行时不会被修改。
- 使用 Symbol 标记，避免同一个运行时被重复处理。
