### PR TITLE
feat: 真境剧诗练度统计图片并入单条转发消息，剧诗开幕试用角色等级更正为90

### DIFF
--- a/apps/profile/ProfileStat.js
+++ b/apps/profile/ProfileStat.js
@@ -582,7 +582,7 @@ const ProfileStat = {
           abbr: char.abbr,
           star: char.star,
           face: char.face,
-          level: 80,
+          level: 90,
           cons: 0,
           talent: {
             a: {

--- a/apps/profile/ProfileStat.js
+++ b/apps/profile/ProfileStat.js
@@ -4,6 +4,7 @@ import moment from 'moment'
 import lodash from 'lodash'
 import fetch from 'node-fetch'
 import * as cheerio from 'cheerio'
+import common from '../../../../lib/common/common.js'
 
 const ProfileStat = {
   async stat (e) {
@@ -224,8 +225,7 @@ const ProfileStat = {
     if (monsterInfo) {
       response.push(monsterInfo)
     }
-    response = response.join('\n')
-    e.reply(response)
+    return response.join('\n')
   },
 
   getElementInfo(elements) {
@@ -685,6 +685,8 @@ const ProfileStat = {
 
     
     let filterFunc = (x) => true
+    // 图片合并到同一条转发消息
+    let roleCombatText = null
     if (isRole) {
       let infoSource = Cfg.get('roleCharInfoSource', 1)
       let datasetName
@@ -753,8 +755,8 @@ const ProfileStat = {
       let invitationCharacterIds = ProfileStat.extractInvitationCharacterIds(currentMazeData)
       let elements = ProfileStat.extractElements(currentMazeData)
       
-      // 发送简要的信息
-      ProfileStat.sendRoleCombatInfo(e, elements, initialCharacterIds, invitationCharacterIds, monsterInfo)
+      // 改为收集文字
+      roleCombatText = ProfileStat.sendRoleCombatInfo(e, elements, initialCharacterIds, invitationCharacterIds, monsterInfo)
 
       avatarRet = ProfileStat.mergeStart(avatarRet, initialCharacterIds)
       filterFunc = ProfileStat.getRoleFilterFunc(e, elements, invitationCharacterIds)
@@ -806,7 +808,7 @@ const ProfileStat = {
     }
 
     let tpl = mode === 'avatar' ? 'character/avatar-list' : 'character/profile-stat'
-    return await Common.render(tpl, {
+    const imgBase64 = await Common.render(tpl, {
       save_id: uid,
       uid,
       info,
@@ -817,7 +819,20 @@ const ProfileStat = {
       week,
       avatars: avatarRet,
       game
-    }, { e, scale: 1.4 })
+    }, { e, scale: 1.4, retType: 'base64' })
+    // puppeteer.screenshot 已用 segment.image 包过
+    if (roleCombatText && imgBase64) {
+      const forwardMsgs = [
+        roleCombatText,
+        imgBase64
+      ]
+      const forwardMsg = await common.makeForwardMsg(e, forwardMsgs, `幻想真境剧诗 · 角色练度统计`)
+      await e.reply(forwardMsg)
+      return true
+    }
+
+    // 其他模式维持原行为
+    return await e.reply(imgBase64)
   }
 }
 export default ProfileStat


### PR DESCRIPTION
## 变更说明

`#202XXXX幻想真境剧诗练度统计` 原本会**分两条消息回复**（先文字信息、后练度统计图），消息过长，经常一堆人同时使用该指令，使得群内刷屏明显。本 PR 将文字与图片合并进**同一条转发消息**，并同步修复开幕试用角色显示等级（我寻思怎么这么久都没人管一下开幕试用角色等级还是80？）。

改动位于 `apps/profile/ProfileStat.js`：

1. **转发合并（来自睡酱）**
   - `sendRoleCombatInfo` 不再直接回复，改为返回拼接字符串
   - `render` 收集剧诗相关文字，末尾将文字与统计图通过 `common.makeForwardMsg` 合并为单条转发
2. **试用角色等级修复**
   - `mergeStart` 中幻想真境剧诗开幕试用角色等级由 `80` 更正为 `90`，与游戏内开幕试用角色一致

## 行为变化

| 指令 | 变更前 | 变更后 |
|------|--------|--------|
| `#202610剧诗角色列表` | 触发关键字避让 / 文字+图片分两条回复 | 单一转发消息：文字信息 + 统计图 |

## 自测

- 触发剧诗练度统计：确认文字（限制元素/开幕角色/特邀角色/怪物信息）与统计图合并在一条转发中