### PR TITLE
fix: 修复历史卡池记录bug

### DIFF
--- a/apps/gacha/Gacha.js
+++ b/apps/gacha/Gacha.js
@@ -2,7 +2,7 @@ import { Common } from '#miao'
 import { getTargetUid } from '../profile/ProfileCommon.js'
 import GachaData from './GachaData.js'
 import GachaPool from './GachaPool.js'
-import { Button, Character, Player } from '#miao.models'
+import { Button, Character, Player, Weapon } from '#miao.models'
 
 let Gacha = {
   async detail (e) {
@@ -113,13 +113,15 @@ let Gacha = {
       return false
     }
     let { game, version, half } = param
+    // 上下半英文标识：无/空 → all，上半 → up，下半 → down，其他值保留原值
+    let half_key = !half ? 'all' : half === '上半' ? 'up' : half === '下半' ? 'down' : half
     let pools = GachaPool.getData(game, version, half)
     if (!pools.length) {
-      e.reply(`未找到${game === 'sr' ? '星铁' : ''}${version}${half}的卡池信息`)
+      e.reply(`未找到 ${game === 'sr' ? '星铁' : '原神'}${version}${half} 的卡池信息`)
       return true
     }
     e.reply(await Common.render('gacha/gacha-info', {
-      save_id: `pool-${game}-${version}-${half}`,
+      save_id: `pool-${game}-${version}-${half_key}`,
       pools,
       game,
       elem: game === 'sr' ? 'sr' : 'hydro'
@@ -153,12 +155,30 @@ let Gacha = {
     let simple = !isDetail
     let result = GachaPool.searchByItem(item, simple, isSrPrefix)
     if (!result) {
-      e.reply(`未找到该${item}`)
+      e.reply(`未找到 ${item} 的卡池信息`)
       return true
     }
     let { game, pools } = result
+    // 解析标准名与类型，生成稳定的英文缓存 id
+    let resolved = GachaPool.resolveItem(item, game)
+    let item_type = 'unknown'
+    let item_id = 'unknown'
+    if (resolved) {
+      let model = resolved.type === 'char'
+        ? Character.get(resolved.name, resolved.game)
+        : Weapon.get(resolved.name, resolved.game)
+      if (model) {
+        if (model.star) {
+          item_type = `${resolved.type}${model.star}`
+        }
+        if (model.id !== undefined && model.id !== null && model.id !== '') {
+          item_id = model.id
+        }
+      }
+    }
+    let simple_key = simple ? 'simple' : 'detail'
     e.reply(await Common.render('gacha/gacha-info', {
-      save_id: `pool-${game}-item-${encodeURIComponent(item)}`,
+      save_id: `pool-${game}-${item_type}-${item_id}-${simple_key}`,
       pools,
       game,
       elem: game === 'sr' ? 'sr' : 'hydro'


### PR DESCRIPTION
## 优化卡池查询 `html` 缓存 ID 生成逻辑

### 修改内容

**文件：** `apps/gacha/Gacha.js`

#### 1. 优化版本卡池查询的 save_id

- 将 `half` 字段中的中文替换为英文标识`half_key` 
- `undefined` / `null` / 不存在 → `all`
- `上半` → `up`
- `下半` → `down`


#### 2. 优化穿透查询的 save_id

- 新增 `item_type`：根据查询项在卡池数据中的位置自动识别类型（`char5` / `char4` / `weapon5` / `weapon4`）
- 新增 `item_id`：从 `Character` / `Weapon` 模型中查询对应标准 ID
- 新增 `simple_key`：根据查询模式标注 `simple` 或 `detail`


### 改动说明

- 统一缓存 ID 命名规范，避免中文路径导致的潜在编码问题
- 不影响现有功能和数据查询逻辑