### PR TITLE
补充多处星扩散相关伤害计算条件

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,14 @@
+# 2.5.18
+
+* 新增历史卡池查询与角色/武器卡池穿透查询  **@yanpd01**
+  * 支持按照版本号及上下半查询原神、星铁历史卡池信息
+  * 示例：#6.0卡池   #6.7上半卡池   *3.0卡池    *4.1下半卡池
+  * 支持根据角色名或武器名反向查询其历史卡池
+  * 示例：#雾切卡池   *白厄卡池
+
 # 2.5.17
 
-* 新增伤害计算用的自定义参数 params
+* 新增伤害计算用的自定义参数 params **@冰翼**
   * 该参数为对象类型，诸如星超导层数、星辉风旋计数等，均通过此参数传入
   * 示例1：`basic(calc(attr.atk) * talent.a['重击冷凝射线星超导伤害'] / 100, '', 'stellarConduct', '', { stellarConductCount : 12 })`
   * 若在相关角色的calc.js未传入此参数，则默认为最大 12 层。**注意 basic 模式下时，{ stellarConductCount : 12 } 前方的''不能省略**
@@ -10,17 +18,13 @@
 
 # 2.5.16
 
-* 更新原神7.1v1、星铁4.5相关数据与资源
-
-*2026-08-20 miao-plugin 自定义角色别名功能
+* 更新原神7.1v1、星铁4.5相关数据与资源  **@yanpd01**
 * 在 miao-plugin（Yunzai 插件）实现了自定义角色别名配置 + 机器人命令，分支 `feat-custom-alias-command`，提交 `9f156e11`（基于 master 54b88fc4）。
-
   * 新增 `apps/alias.js`：#喵喵别名设置/删除/帮助 系列命令（App.init + app.reg 模式）
   * 新增 `models/alias/CustomAlias.js`：cfg 解析（兼容中英文冒号/逗号）、Meta 内存别名合并与回滚（恢复被覆盖的预设）、fs.watchFile 热更新（1s 轮询 + 0.5s 防抖）、临时文件+rename 原子写 + Promise 链写锁
   * `models/index.js`：meta 加载循环后动态 import CustomAlias 并 init（幂等）
   * `apps/index.js`：注册 alias app
   * `.gitignore`：+config/alias_gs.cfg、config/alias_sr.cfg
-
 
 # 2.5.1 ~ 2.5.15
 

--- a/resources/meta-gs/artifact/calc.js
+++ b/resources/meta-gs/artifact/calc.js
@@ -631,6 +631,7 @@ const buffs = {
   影中沉凝的幻灭: {
     2: attr('atkPct', 18),
     4: {
+      check: ({ element }) => ['雷', '冰'].includes(element),
       title: '超导反应造成的伤害提升[superConduct]%；星超导反应造成的伤害提升[stellarConduct]%；攻击受到超导或星超导反应影响的敌人暴击率提高[cpct]%',
       data: {
         superConduct: 80,
@@ -643,10 +644,24 @@ const buffs = {
   炉火融炼之心: {
     2: attr('atkPct', 18),
     4: {
+      check: ({ element }) => ['雷', '风', '冰'].includes(element),
       title: '装备者触发星烁反应或造成星烁反应伤害后的12秒内，攻击力提升[atkPct]%，队伍中附近的所有角色造成的星烁反应伤害提升[stellarConduct]%。',
       data: {
         atkPct: 12,
         stellarConduct: 50
+      }
+    }
+  },
+
+  血红之证: {
+    2: attr('atkPct', 18),
+    4: {
+      check: ({ element }) => ['风', '冰'].includes(element),
+      title: '装备者触发星扩散反应后的10秒内，暴击率提升[cpct]%，星扩散反应伤害提升[stellarSwirl]%。',
+      data: {
+        cpct: 16,
+        stellarSwirl: 40,
+        stellarVortex: 40
       }
     }
   }

--- a/resources/meta-gs/artifact/calc.js
+++ b/resources/meta-gs/artifact/calc.js
@@ -178,7 +178,8 @@ const buffs = {
       data: {
         swirl: 60,
         fykx: 40,
-        stellarSwirl: 20
+        stellarSwirl: 20,
+        stellarVortex: 20
       }
     }
   },

--- a/resources/meta-gs/weapon/catalyst/calc.js
+++ b/resources/meta-gs/weapon/catalyst/calc.js
@@ -291,10 +291,12 @@ export default function (step, staticStep) {
         mastery: step(60)
       }
     }, {
-      check: ({ element }) => ['冰', '雷', '风'].includes(element),
+      check: ({ element }) => ['雷', '风', '冰'].includes(element),
       title: '触发星烁反应后，星烁反应伤害提升[stellarConduct]%',
       refine: {
-        stellarConduct: step(16)
+        stellarConduct: step(16),
+        stellarSwirl: step(16),
+        stellarVortex: step(16)
       }
     }]
   }

--- a/resources/meta-gs/weapon/claymore/calc.js
+++ b/resources/meta-gs/weapon/claymore/calc.js
@@ -249,7 +249,7 @@ export default function (step, staticStep) {
         mastery: step(120)
       }
     }, {
-      check: ({ element }) => ['冰', '雷', '风'].includes(element),
+      check: ({ element }) => ['雷', '风', '冰'].includes(element),
       title: '触发星烁反应后，元素精通提高[mastery]点',
       refine: {
         mastery: step(120)
@@ -261,7 +261,7 @@ export default function (step, staticStep) {
         mastery: step(64)
       }
     }, {
-      check: ({ element }) => ['冰', '雷', '风'].includes(element),
+      check: ({ element }) => ['雷', '风', '冰'].includes(element),
       title: '触发星烁反应后，攻击力提高[atkPct]%',
       refine: {
         atkPct: step(16)

--- a/resources/meta-gs/weapon/polearm/calc.js
+++ b/resources/meta-gs/weapon/polearm/calc.js
@@ -237,7 +237,7 @@ export default function (step, staticStep) {
       }
     },
     戍望谣歌: {
-      check: ({ element }) => ['冰', '雷', '风'].includes(element),
+      check: ({ element }) => ['雷', '风', '冰'].includes(element),
       title: '触发星烁反应后，攻击力提升[atkPct]%',
       refine: {
         atkPct: step(20)

--- a/resources/meta-gs/weapon/sword/calc.js
+++ b/resources/meta-gs/weapon/sword/calc.js
@@ -328,7 +328,9 @@ export default function (step, staticStep) {
       check: ({ element }) => ['冰', '雷', '风'].includes(element),
       title: '触发星烁反应后，星烁反应伤害提升[stellarConduct]%',
       refine: {
-        stellarConduct: step(16)
+        stellarConduct: step(16),
+        stellarSwirl: step(16),
+        stellarVortex: step(16)
       }
     }],
     白湖冬羽: [{


### PR DESCRIPTION
涉及圣遗物——血红之证、翠绿之影；
以及各个星扩散、星烁反应相关的4星武器。